### PR TITLE
增加 “随机” 主页预设

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -68,7 +68,17 @@ Download:
                     Exit Sub
                 End If
             Case 3
-                Select Case Setup.Get("UiCustomPreset")
+                Static RandomFlag As Boolean
+                Static PresetIndex As Integer
+                Dim Preset = Setup.Get("UiCustomPreset")
+                If Preset <> 12 Then '非随机预设
+                    PresetIndex = Preset
+                ElseIf RandomFlag = False Then '确保每次启动只生成一次随机数
+                    Log("[Page] 主页预设：随机预设")
+                    PresetIndex = New Random().Next(0, 12) '生成0-11的随机数
+                    RandomFlag = True
+                End If
+                Select Case PresetIndex
                     Case 0
                         Log("[Page] 主页预设：你知道吗")
                         Content = "

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -68,14 +68,14 @@ Download:
                     Exit Sub
                 End If
             Case 3
-                Static RandomFlag As Boolean
+                Static RandomFlag As Boolean = False '此 Flag 仅在生成随机数后赋值为 True
                 Static PresetIndex As Integer
                 Dim Preset = Setup.Get("UiCustomPreset")
                 If Preset <> 12 Then '非随机预设
                     PresetIndex = Preset
                 ElseIf RandomFlag = False Then '确保每次启动只生成一次随机数
                     Log("[Page] 主页预设：随机预设")
-                    PresetIndex = New Random().Next(0, 12) '生成0-11的随机数
+                    PresetIndex = New Random().Next(0, 12) '生成 0-11 的随机数
                     RandomFlag = True
                 End If
                 Select Case PresetIndex

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupUI.xaml
@@ -249,6 +249,7 @@
                             <local:MyComboBoxItem Content="PCL 新功能说明书（作者：WForst-Breeze）" />
                             <local:MyComboBoxItem Content="OpenMCIM 仪表盘（作者：SALTWOOD）" />
                             <local:MyComboBoxItem Content="杂志主页（作者：CreeperIsASpy）" />
+                            <local:MyComboBoxItem Content="随机预设（每次启动随机选择一个预设）" />
                         </local:MyComboBox>
                     </Grid>
                 </StackPanel>


### PR DESCRIPTION
昨天提了个issue #5425 希望增加随机主页预设，今天被关闭了，不知道是因为作者没有精力还是其他原因拒绝了。
如果是作者精力不足，我想着提个PR把功能实现了，如果是因为其他原因不想添加，那就忽略这个吧。

> （虽然有人说随机刷新浪费预设托管服务器流量... 但我觉得选择随机预设的人应该不多吧，再加上一个人一天也不会重复打开多少次启动器...）