### PR TITLE
fix(CustomMainpage): 设法捕捉在布局阶段的自定义主页异常

### DIFF
--- a/Plain Craft Launcher 2/Controls/ExceptionCatcherStackPanel.vb
+++ b/Plain Craft Launcher 2/Controls/ExceptionCatcherStackPanel.vb
@@ -1,0 +1,50 @@
+﻿Public Class ExceptionCatcherStackPanel
+    Inherits StackPanel
+
+    ''' <summary>
+    ''' 抓到异常之后会触发这个事件，Handled 为 False 的话会再抛出去，应用程序此时正在被挂起，请不要使用 MyMsgBox
+    ''' </summary>
+    Public Custom Event ExceptionOccured As ExceptionOccuredEventHandler
+        AddHandler(value As ExceptionOccuredEventHandler)
+            [AddHandler](ExceptionOccuredEvent, value)
+        End AddHandler
+        RemoveHandler(value As ExceptionOccuredEventHandler)
+            [RemoveHandler](ExceptionOccuredEvent, value)
+        End RemoveHandler
+        RaiseEvent(sender As Object, e As ExceptionOccuredEventArgs)
+            [RaiseEvent](e)
+        End RaiseEvent
+    End Event
+    Public Shared ReadOnly ExceptionOccuredEvent As RoutedEvent =
+        EventManager.RegisterRoutedEvent("ExceptionOccured", RoutingStrategy.Direct, GetType(ExceptionOccuredEventHandler), GetType(ExceptionCatcherStackPanel))
+    Public Delegate Sub ExceptionOccuredEventHandler(sender As Object, e As ExceptionOccuredEventArgs)
+    Public Class ExceptionOccuredEventArgs
+        Inherits RoutedEventArgs
+        Public ReadOnly Ex As Exception
+        Public Sub New(Ex As Exception)
+            Me.Ex = Ex
+        End Sub
+    End Class
+    Private Function RaiseExEventAndReturnIfHandled(Ex As Exception) As Boolean
+        Dim e As New ExceptionOccuredEventArgs(Ex) With {.RoutedEvent = ExceptionOccuredEvent}
+        RaiseEvent ExceptionOccured(Me, e)
+        Return e.Handled
+    End Function
+
+    Protected Overrides Function MeasureOverride(constraint As Size) As Size
+        Try
+            Return MyBase.MeasureOverride(constraint)
+        Catch ex As Exception
+            If Not RaiseExEventAndReturnIfHandled(ex) Then Throw
+        End Try
+    End Function
+
+    Protected Overrides Function ArrangeOverride(arrangeSize As Size) As Size
+        Try
+            Return MyBase.ArrangeOverride(arrangeSize)
+        Catch ex As Exception
+            If Not RaiseExEventAndReturnIfHandled(ex) Then Throw
+        End Try
+    End Function
+
+End Class

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml
@@ -6,8 +6,7 @@
     xmlns:local="clr-namespace:PCL"> <!-- 不知道为啥只有这个文件不能在 XAML 设置 PanScroll -->
     <local:MyScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" x:Name="PanBack">
         <StackPanel Name="PanMain" Margin="25,25,25,10" Grid.IsSharedSizeScope="True">
-            <StackPanel x:Name="PanCustom">
-            </StackPanel>
+            <local:ExceptionCatcherStackPanel x:Name="PanCustom" />
             <local:MyCard Margin="0,0,0,15" Title="快照版提示" x:Name="PanHint">
                 <local:MyIconButton LogoScale="1.1" Logo="F1 M2,0 L0,2 8,10 0,18 2,20 10,12 18,20 20,18 12,10 20,2 18,0 10,8 2,0Z"
                                     Height="20" Margin="10" HorizontalAlignment="Right" VerticalAlignment="Top"

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -207,6 +207,22 @@ Download:
         Log("[Page] 已清空主页缓存")
     End Sub
 
+    Private Sub OnCustomMainpageWPFException(sender As Object, e As ExceptionCatcherStackPanel.ExceptionOccuredEventArgs) Handles PanCustom.ExceptionOccured
+        e.Handled = True
+        PanCustom.Children.Clear()
+        RunInNewThread(
+            Sub()
+                If ModeDebug Then
+                    Log(e.Ex, "显示主页界面失败")
+                    If MyMsgBox($"主页内容编写有误，请根据下列错误信息进行检查：{vbCrLf}{GetExceptionSummary(e.Ex)}", "显示主页界面失败", "重试", "取消") = 1 Then
+                        RunInUi(AddressOf ForceRefresh)
+                    End If
+                Else
+                    Log(e.Ex, "显示主页界面失败", LogLevel.Hint)
+                End If
+            End Sub)
+    End Sub
+
     ''' <summary>
     ''' 从文本内容中加载主页。
     ''' 必须在 UI 线程调用。

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -182,6 +182,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Controls\ExceptionCatcherStackPanel.vb" />
     <Compile Include="Controls\IMyRadio.vb" />
     <Compile Include="Controls\MyComboBox.vb" />
     <Compile Include="Controls\MyComboBoxItem.vb" />
@@ -195,9 +196,6 @@
     <Compile Include="Controls\MyIconTextButton.xaml.vb">
       <DependentUpon>MyIconTextButton.xaml</DependentUpon>
     </Compile>
-
-
-
     <Compile Include="Modules\Minecraft\ModComp.vb" />
     <Compile Include="Modules\Minecraft\ModJava.vb" />
     <Compile Include="Modules\Minecraft\ModMod.vb" />
@@ -501,7 +499,6 @@
       <DependentUpon>FormMain.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-
     <Page Include="Pages\PageVersion\MyLocalModItem.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -957,7 +954,6 @@
     <Resource Include="Images\Heads\MCBBS.png" />
   </ItemGroup>
   <ItemGroup>
-
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Blocks\NeoForge.png" />


### PR DESCRIPTION
在自定义主页中写下以下代码会直接崩掉 PCL 程序，因为 WPF 会在显示时每帧抛个异常。
```xaml
<Control>
    <Control.Template>
        <ControlTemplate TargetType="Control">
            <!--不给 x:Array 设置 Type 会引发异常，
                模板的内容的解析时间不在读 xaml 时而在显示时-->
            <x:Array />
        </ControlTemplate>
    </Control.Template>
</Control>
```
我并不清楚我这么修能解决多少问题以及有没有残留的问题……只是能把这个解决掉就是了

~极低优先度预定~
___
本 PR 是为了方便主页作者在调试时不要因为一个疏忽（在模板里写了会抛例如 ArgumentException 的代码）而崩掉 PCL 