### PR TITLE
feat(PageSelectLeft): 可以调整 MC 文件夹列表里文件夹的顺序

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
@@ -39,6 +39,8 @@
                                 <ContextMenu xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="clr-namespace:PCL;assembly=Plain Craft Launcher 2">
                                     <local:MyMenuItem x:Name="Rename" Header="重命名" Padding="0,2,0,0" Icon="F1 M 53.2929,21.2929L 54.7071,22.7071C 56.4645,24.4645 56.4645,27.3137 54.7071,29.0711L 52.2323,31.5459L 44.4541,23.7677L 46.9289,21.2929C 48.6863,19.5355 51.5355,19.5355 53.2929,21.2929 Z M 31.7262,52.052L 23.948,44.2738L 43.0399,25.182L 50.818,32.9601L 31.7262,52.052 Z M 23.2409,47.1023L 28.8977,52.7591L 21.0463,54.9537L 23.2409,47.1023 Z"/>
                                     <local:MyMenuItem x:Name="Open" Header="打开" Icon="F1 M 19,50L 28,34L 63,34L 54,50L 19,50 Z M 19,28.0001L 35,28C 36,25 37.4999,24.0001 37.4999,24.0001L 48.75,24C 49.3023,24 50,24.6977 50,25.25L 50,28L 54,28.0001L 54,32L 27,32L 19,46.4L 19,28.0001 Z"/>
+                                    <local:MyMenuItem x:Name="Up" Header="上移" Padding="0,2,0,0" Icon="M164.1472 731.0336h695.808c40.1408 0 60.3136-48.5376 31.8464-77.0048L543.8464 306.176c-17.6128-17.6128-46.1824-17.6128-63.7952 0L132.1984 654.0288c-28.3648 28.4672-8.2944 77.0048 31.9488 77.0048z"/>
+                                    <local:MyMenuItem x:Name="Down" Header="下移" Icon="M164.1472-731.0336h695.808c40.1408 0 60.3136 48.5376 31.8464 77.0048L543.8464-306.176c-17.6128 17.6128-46.1824 17.6128-63.7952 0L132.1984-654.0288c-28.3648-28.4672-8.2944-77.0048 31.9488-77.0048z"/>
                                     <local:MyMenuItem x:Name="Refresh" Header="刷新" Icon="F1 M 38,20.5833C 42.9908,20.5833 47.4912,22.6825 50.6667,26.046L 50.6667,17.4167L 55.4166,22.1667L 55.4167,34.8333L 42.75,34.8333L 38,30.0833L 46.8512,30.0833C 44.6768,27.6539 41.517,26.125 38,26.125C 31.9785,26.125 27.0037,30.6068 26.2296,36.4167L 20.6543,36.4167C 21.4543,27.5397 28.9148,20.5833 38,20.5833 Z M 38,49.875C 44.0215,49.875 48.9963,45.3932 49.7703,39.5833L 55.3457,39.5833C 54.5457,48.4603 47.0852,55.4167 38,55.4167C 33.0092,55.4167 28.5088,53.3175 25.3333,49.954L 25.3333,58.5833L 20.5833,53.8333L 20.5833,41.1667L 33.25,41.1667L 38,45.9167L 29.1487,45.9167C 31.3231,48.3461 34.483,49.875 38,49.875 Z"/>
                                     <local:MyMenuItem x:Name="Delete" Header="删除" Padding="0,0,0,2" Icon="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z "/>
                                 </ContextMenu>
@@ -49,6 +51,8 @@
                                     <local:MyMenuItem x:Name="Remove" Header="复原名称" Padding="0,2,0,0" Icon="F1 M 53.2929,21.2929L 54.7071,22.7071C 56.4645,24.4645 56.4645,27.3137 54.7071,29.0711L 52.2323,31.5459L 44.4541,23.7677L 46.9289,21.2929C 48.6863,19.5355 51.5355,19.5355 53.2929,21.2929 Z M 31.7262,52.052L 23.948,44.2738L 43.0399,25.182L 50.818,32.9601L 31.7262,52.052 Z M 23.2409,47.1023L 28.8977,52.7591L 21.0463,54.9537L 23.2409,47.1023 Z"/>
                                     <local:MyMenuItem x:Name="Rename" Header="重命名" Icon="F1 M 53.2929,21.2929L 54.7071,22.7071C 56.4645,24.4645 56.4645,27.3137 54.7071,29.0711L 52.2323,31.5459L 44.4541,23.7677L 46.9289,21.2929C 48.6863,19.5355 51.5355,19.5355 53.2929,21.2929 Z M 31.7262,52.052L 23.948,44.2738L 43.0399,25.182L 50.818,32.9601L 31.7262,52.052 Z M 23.2409,47.1023L 28.8977,52.7591L 21.0463,54.9537L 23.2409,47.1023 Z"/>
                                     <local:MyMenuItem x:Name="Open" Header="打开" Icon="F1 M 19,50L 28,34L 63,34L 54,50L 19,50 Z M 19,28.0001L 35,28C 36,25 37.4999,24.0001 37.4999,24.0001L 48.75,24C 49.3023,24 50,24.6977 50,25.25L 50,28L 54,28.0001L 54,32L 27,32L 19,46.4L 19,28.0001 Z"/>
+                                    <local:MyMenuItem x:Name="Up" Header="上移" Padding="0,2,0,0" Icon="M164.1472 731.0336h695.808c40.1408 0 60.3136-48.5376 31.8464-77.0048L543.8464 306.176c-17.6128-17.6128-46.1824-17.6128-63.7952 0L132.1984 654.0288c-28.3648 28.4672-8.2944 77.0048 31.9488 77.0048z"/>
+                                    <local:MyMenuItem x:Name="Down" Header="下移" Icon="M164.1472-731.0336h695.808c40.1408 0 60.3136 48.5376 31.8464 77.0048L543.8464-306.176c-17.6128 17.6128-46.1824 17.6128-63.7952 0L132.1984-654.0288c-28.3648-28.4672-8.2944-77.0048 31.9488-77.0048z"/>
                                     <local:MyMenuItem x:Name="Refresh" Header="刷新" Icon="F1 M 38,20.5833C 42.9908,20.5833 47.4912,22.6825 50.6667,26.046L 50.6667,17.4167L 55.4166,22.1667L 55.4167,34.8333L 42.75,34.8333L 38,30.0833L 46.8512,30.0833C 44.6768,27.6539 41.517,26.125 38,26.125C 31.9785,26.125 27.0037,30.6068 26.2296,36.4167L 20.6543,36.4167C 21.4543,27.5397 28.9148,20.5833 38,20.5833 Z M 38,49.875C 44.0215,49.875 48.9963,45.3932 49.7703,39.5833L 55.3457,39.5833C 54.5457,48.4603 47.0852,55.4167 38,55.4167C 33.0092,55.4167 28.5088,53.3175 25.3333,49.954L 25.3333,58.5833L 20.5833,53.8333L 20.5833,41.1667L 33.25,41.1667L 38,45.9167L 29.1487,45.9167C 31.3231,48.3461 34.483,49.875 38,49.875 Z"/>
                                     <local:MyMenuItem x:Name="Delete" Header="删除" Padding="0,0,0,2" Icon="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z "/>
                                 </ContextMenu>
@@ -58,6 +62,8 @@
                                 <ContextMenu xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="clr-namespace:PCL;assembly=Plain Craft Launcher 2">
                                     <local:MyMenuItem x:Name="Rename" Header="重命名" Padding="0,2,0,0" Icon="F1 M 53.2929,21.2929L 54.7071,22.7071C 56.4645,24.4645 56.4645,27.3137 54.7071,29.0711L 52.2323,31.5459L 44.4541,23.7677L 46.9289,21.2929C 48.6863,19.5355 51.5355,19.5355 53.2929,21.2929 Z M 31.7262,52.052L 23.948,44.2738L 43.0399,25.182L 50.818,32.9601L 31.7262,52.052 Z M 23.2409,47.1023L 28.8977,52.7591L 21.0463,54.9537L 23.2409,47.1023 Z"/>
                                     <local:MyMenuItem x:Name="Open" Header="打开" Icon="F1 M 19,50L 28,34L 63,34L 54,50L 19,50 Z M 19,28.0001L 35,28C 36,25 37.4999,24.0001 37.4999,24.0001L 48.75,24C 49.3023,24 50,24.6977 50,25.25L 50,28L 54,28.0001L 54,32L 27,32L 19,46.4L 19,28.0001 Z"/>
+                                    <local:MyMenuItem x:Name="Up" Header="上移" Padding="0,2,0,0" Icon="M164.1472 731.0336h695.808c40.1408 0 60.3136-48.5376 31.8464-77.0048L543.8464 306.176c-17.6128-17.6128-46.1824-17.6128-63.7952 0L132.1984 654.0288c-28.3648 28.4672-8.2944 77.0048 31.9488 77.0048z"/>
+                                    <local:MyMenuItem x:Name="Down" Header="下移" Icon="M164.1472-731.0336h695.808c40.1408 0 60.3136 48.5376 31.8464 77.0048L543.8464-306.176c-17.6128 17.6128-46.1824 17.6128-63.7952 0L132.1984-654.0288c-28.3648-28.4672-8.2944-77.0048 31.9488-77.0048z"/>
                                     <local:MyMenuItem x:Name="Refresh" Header="刷新" Icon="F1 M 38,20.5833C 42.9908,20.5833 47.4912,22.6825 50.6667,26.046L 50.6667,17.4167L 55.4166,22.1667L 55.4167,34.8333L 42.75,34.8333L 38,30.0833L 46.8512,30.0833C 44.6768,27.6539 41.517,26.125 38,26.125C 31.9785,26.125 27.0037,30.6068 26.2296,36.4167L 20.6543,36.4167C 21.4543,27.5397 28.9148,20.5833 38,20.5833 Z M 38,49.875C 44.0215,49.875 48.9963,45.3932 49.7703,39.5833L 55.3457,39.5833C 54.5457,48.4603 47.0852,55.4167 38,55.4167C 33.0092,55.4167 28.5088,53.3175 25.3333,49.954L 25.3333,58.5833L 20.5833,53.8333L 20.5833,41.1667L 33.25,41.1667L 38,45.9167L 29.1487,45.9167C 31.3231,48.3461 34.483,49.875 38,49.875 Z"/>
                                     <local:MyMenuItem x:Name="Remove" Header="移出列表" Icon="F1 M 23.3428,25.205L 23.3805,25.4461C 23.9229,27.177 30.261,29.0992 38,29.0992C 45.7386,29.0992 52.0765,27.1771 52.6194,25.4463L 52.6571,25.205C 52.6571,23.3616 46.0949,21.3109 38,21.3109C 29.9051,21.3109 23.3428,23.3616 23.3428,25.205 Z M 23.3428,53.0204L 19.1571,26.2111C 19.0534,25.8817 19,25.5459 19,25.205C 19,20.9036 27.5066,17.4167 38,17.4167C 48.4934,17.4167 57,20.9036 57,25.205C 57,25.5459 56.9466,25.8818 56.8429,26.2112L 52.6571,53.0204L 52.5974,53.0204C 51.9241,56.1393 45.6457,58.5833 38,58.5833C 30.3543,58.5833 24.076,56.1393 23.4026,53.0204L 23.3428,53.0204 Z M 51.8228,30.5485C 48.3585,32.0537 43.4469,32.9933 38,32.9933C 32.5531,32.9933 27.6415,32.0537 24.1771,30.5484L 27.5988,52.464L 27.6857,52.464C 27.6857,53.3857 32.3036,54.6892 38,54.6892C 43.6964,54.6892 48.3143,53.3857 48.3143,52.464L 48.4011,52.464L 51.8228,30.5485 Z "/>
                                     <local:MyMenuItem x:Name="Delete" Header="删除" Padding="0,0,0,2" Icon="F1 M 26.9166,22.1667L 37.9999,33.25L 49.0832,22.1668L 53.8332,26.9168L 42.7499,38L 53.8332,49.0834L 49.0833,53.8334L 37.9999,42.75L 26.9166,53.8334L 22.1666,49.0833L 33.25,38L 22.1667,26.9167L 26.9166,22.1667 Z "/>
@@ -71,6 +77,11 @@
                 CType(ContMenu.FindName("Delete"), MyMenuItem).AddHandler(MyMenuItem.ClickEvent, New RoutedEventHandler(AddressOf FrmSelectLeft.Delete_Click))
                 CType(ContMenu.FindName("Rename"), MyMenuItem).AddHandler(MyMenuItem.ClickEvent, New RoutedEventHandler(AddressOf FrmSelectLeft.Rename_Click))
                 CType(ContMenu.FindName("Refresh"), MyMenuItem).AddHandler(MyMenuItem.ClickEvent, New RoutedEventHandler(AddressOf FrmSelectLeft.Refresh_Click))
+                CType(ContMenu.FindName("Up"), MyMenuItem).AddHandler(MyMenuItem.ClickEvent, New RoutedEventHandler(AddressOf FrmSelectLeft.Up_Click))
+                CType(ContMenu.FindName("Down"), MyMenuItem).AddHandler(MyMenuItem.ClickEvent, New RoutedEventHandler(AddressOf FrmSelectLeft.Down_Click))
+                '根据索引值 / 是否为当前文件夹，禁用上移 / 下移
+                If McFolderList.First.Path = Folder.Path OrElse GetPathFromFullPath(Folder.Path) = Path Then CType(ContMenu.FindName("Up"), MyMenuItem).IsEnabled = False
+                If McFolderList.Last.Path = Folder.Path OrElse GetPathFromFullPath(Folder.Path) = Path OrElse (McFolderList(McFolderList.Count - 2).Path = Folder.Path AndAlso GetPathFromFullPath(McFolderList.Last.Path) = Path) Then CType(ContMenu.FindName("Down"), MyMenuItem).IsEnabled = False
                 '构建框架与图表按钮
                 Dim NewItem As New MyListItem With {.IsScaleAnimationEnabled = False, .Type = MyListItem.CheckType.RadioBox, .MinPaddingRight = 30, .Title = Folder.Name, .Info = Folder.Path, .Height = 40, .ContextMenu = ContMenu, .Tag = Folder}
                 AddHandler NewItem.Changed, AddressOf FrmSelectLeft.Folder_Change
@@ -354,6 +365,32 @@
     Public Sub Refresh_Click(sender As Object, e As RoutedEventArgs)
         Dim Data As McFolder = CType(CType(CType(sender.Parent, ContextMenu).Parent, Primitives.Popup).PlacementTarget, MyListItem).Tag
         RefreshCurrent(Data.Path)
+    End Sub
+    Public Sub Up_Click(sender As Object, e As RoutedEventArgs)
+        Dim Folder As McFolder = CType(CType(CType(sender.Parent, ContextMenu).Parent, Primitives.Popup).PlacementTarget, MyListItem).Tag
+        Dim FolderItem As String = $"{Folder.Name}>{Folder.Path}"
+        Dim Folders As New List(Of String)(Setup.Get("LaunchFolders").ToString.Split("|"))
+        Dim Index As Integer = Folders.IndexOf(FolderItem)
+        If Index = 0 Then Return
+        Folders.RemoveAt(Index)
+        Index -= 1
+        Folders.Insert(Index, FolderItem)
+        '保存
+        Setup.Set("LaunchFolders", Join(Folders, "|"))
+        McFolderListLoader.Start(IsForceRestart:=True)
+    End Sub
+    Public Sub Down_Click(sender As Object, e As RoutedEventArgs)
+        Dim Folder As McFolder = CType(CType(CType(sender.Parent, ContextMenu).Parent, Primitives.Popup).PlacementTarget, MyListItem).Tag
+        Dim FolderItem As String = $"{Folder.Name}>{Folder.Path}"
+        Dim Folders As New List(Of String)(Setup.Get("LaunchFolders").ToString.Split("|"))
+        Dim Index As Integer = Folders.IndexOf(FolderItem)
+        If Index = Folders.Count - 1 Then Return
+        Folders.RemoveAt(Index)
+        Index += 1
+        Folders.Insert(Index, FolderItem)
+        '保存
+        Setup.Set("LaunchFolders", Join(Folders.ToArray, "|"))
+        McFolderListLoader.Start(IsForceRestart:=True)
     End Sub
     Public Sub RefreshCurrent() Implements IRefreshable.Refresh
         RefreshCurrent(PathMcFolder)


### PR DESCRIPTION
Closes Hex-Dragon/PCL2#381

目前的行为是：可以调整 **除了当前文件夹以外** 的所有文件夹顺序。

不能调整当前文件夹，是因为设置项 `LaunchFolders` 里面没有当前文件夹，如果添加进去，更新之后还可能会出问题……不过一般人应该也没有这种需求。

如有问题请提出，感谢！

---

- 检索式：`is:pr (文件夹 OR 列表 OR .minecraft) AND 顺序`
- 功能投票：#387
- CE 反馈：PCL-Community/PCL2-CE#194
