### PR TITLE
fix: 搜索旧版本 Forge mod 崩溃

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModComp.vb
@@ -1137,6 +1137,11 @@ Retry:
             If ModrinthThread IsNot Nothing Then ModrinthThread.Join()
             If Task.IsAborted Then Return
 
+            '筛除不是 Forge 的 Mod
+            If IsOldForgeRequest Then
+                RawResults = RawResults.Where(Function(p) Not p.ModLoaders.Any() OrElse p.ModLoaders.Contains(CompModLoaderType.Forge)).ToList
+            End If
+
             '确保存在结果
             Storage.ErrorMessage = Nothing
             If Not RawResults.Any() Then
@@ -1166,11 +1171,6 @@ Retry:
             CurseForgeThread?.Interrupt()
             ModrinthThread?.Interrupt()
         End Try
-
-        '筛除不是 Forge 的 Mod
-        If IsOldForgeRequest Then
-            RawResults = RawResults.Where(Function(p) Not p.ModLoaders.Any() OrElse p.ModLoaders.Contains(CompModLoaderType.Forge)).ToList
-        End If
 
 #End Region
 


### PR DESCRIPTION
- Fix #6692

搜索结果为空需要抛出异常，过滤 Forge 的位置太靠后跳过了这部分逻辑。