### PR TITLE
fix(third-login): 无效的请求参数

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -683,7 +683,7 @@ LoginFinish:
         Dim Name As String = Setup.Get("Cache" & Data.Input.Token & "Name")
         '发送登录请求
         Dim RequestData As New JObject(
-            New JProperty("accessToken", AccessToken), New JProperty("clientToken", ClientToken), New JProperty("requestUser", True))
+            New JProperty("accessToken", AccessToken))
         NetRequestRetry(
             Url:=Data.Input.BaseUrl & "/validate",
             Method:="POST",


### PR DESCRIPTION
干掉了第三方登录中验证登录存在的无效参数（requestUser）

删掉了残余的 clientToken 参数