### PR TITLE
fix: 修复选择 1.21.5- 的 Fabric 版本不显示 Blue 提示以及修改文本

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml
@@ -27,7 +27,7 @@
                         <local:MyHint Text="必须安装 OptiFabric 才能正常使用 OptiFine！" Margin="0,10,0,0" x:Name="HintOptiFabric" Theme="Red" />
                         <local:MyHint Text="安装结束后，请在 Mod 下载中搜索 OptiFabric Origins 并下载，否则 OptiFine 会无法使用！" Margin="0,10,0,0" x:Name="HintOptiFabricOld" Theme="Yellow" />
                         <local:MyHint Text="OptiFine 与一部分 Mod 的兼容性不佳，请谨慎安装。" Margin="0,10,0,0" x:Name="HintModOptiFine" Theme="Yellow" />
-						<local:MyHint Text="1.20.5+ 没有 OptiFabric，无法使用 OptiFine，如需加载光影请考虑使用其他 Mod" Margin="0,10,0,0" x:Name="HintModOptiFineHigh" Theme="Blue" />
+						<local:MyHint Text="1.20.5+ 没有 OptiFabric，无法在 Fabric 中加载，如需加载光影请考虑使用其他 Mod。" Margin="0,10,0,0" x:Name="HintModOptiFineHigh" Theme="Blue" />
 						<local:MyCard Title="Forge" Height="40" Margin="0,12,0,0" x:Name="CardForge" IsSwaped="True" CanSwap="True" SwapLogoRight="True">
                         <StackPanel Margin="20,40,18,15" VerticalAlignment="Top" Name="PanForge" />
                         <Grid x:Name="PanForgeInfo" Height="18" Margin="132,11,15,0" VerticalAlignment="Top" Tag="True">

--- a/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/PageDownloadInstall.xaml.vb
@@ -476,7 +476,7 @@
         Else
             HintModOptiFine.Visibility = Visibility.Collapsed
         End If
-        If SelectedFabric IsNot Nothing AndAlso VersionSortInteger(SelectedMinecraftId, "1.21.4") > 0 Then
+        If SelectedFabric IsNot Nothing AndAlso VersionSortInteger(SelectedMinecraftId, "1.20.4") > 0 Then
             HintModOptiFineHigh.Visibility = Visibility.Visible
         Else
             HintModOptiFineHigh.Visibility = Visibility.Collapsed


### PR DESCRIPTION
<img width="1620" height="940" alt="image" src="https://github.com/user-attachments/assets/c2ed41fb-4f41-40e6-bef7-c1c91be1f580" />
上面这张图是修复之前

好像合并的时候只合并了提示没合并版本判断，依然是 1.21.5+ （
感觉提示文本用我往帮助库提交的更合适一些？
~第一次提交不小心写错了版本号~