### PR TITLE
主页按钮加入非加密设置的写入功能

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModEvent.vb
+++ b/Plain Craft Launcher 2/Modules/ModEvent.vb
@@ -115,6 +115,13 @@
                         PageOtherTest.StartCustomDownload(Data(0), "未知")
                     End Try
 
+                Case "修改设置"
+                    If Setup.IsEncoded(Data(0)) Then
+                        Throw New Exception($"无法修改受加密保护的设置：{Data(0)}")
+                    End If
+                    Setup.Set(Data(0), Data(1))
+                    Hint("已修改设置！", HintType.Finish)
+
                 Case Else
                     MyMsgBox("未知的事件类型：" & Type & vbCrLf & "请检查事件类型填写是否正确，或者 PCL 是否为最新版本。", "事件执行失败")
             End Select

--- a/Plain Craft Launcher 2/Pages/PageSetup/ModSetup.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/ModSetup.vb
@@ -357,6 +357,13 @@
                 Return Not HasIniKey(Version.Path & "PCL\Setup.ini", Key)
         End Select
     End Function
+    ''' <summary>
+    ''' 某个设置项是否加密。
+    ''' </summary>
+    Public Function IsEncoded(Key As String) As Boolean
+        If Not SetupDict.ContainsKey(Key) Then Throw New KeyNotFoundException("未找到设置项：" & Key) With {.Source = Key}
+        Return SetupDict(Key).Encoded
+    End Function
 
     ''' <summary>
     ''' 读取设置。


### PR DESCRIPTION
源 Issue: #6973

------
修改：

* 添加了 “修改设置” 事件
  * 事件数据格式：“设置项键名|要设置的值”
  * 只能更改非加密的设置项
* 在 `ModSetup` 中添加 `IsEncoded` 方法，用于判断某个设置项是否加密