### PR TITLE
fix(MyCard): IsSwaped 未正确转发

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyCard.vb
+++ b/Plain Craft Launcher 2/Controls/MyCard.vb
@@ -332,7 +332,6 @@
             IsSwapped = value
         End Set
     End Property
-    Public Shared ReadOnly IsSwapedProperty As DependencyProperty = DependencyProperty.Register("IsSwaped", GetType(Boolean), GetType(MyCard), New PropertyMetadata(False))
 
     Public Property SwapLogoRight As Boolean = False
     Private IsMouseDown As Boolean = False


### PR DESCRIPTION
当前的最新版中，在自定义主页中设置`IsSwaped`是无效的，修改后可正确转发至`IsSwapped`。