### PR TITLE
fix(ModDownload): 跟进新的 NeoForge 命名方式以正确识别测试版

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -844,7 +844,7 @@
         Public Sub New(ApiName As String)
             IsNeoForge = True
             Me.ApiName = ApiName
-            IsBeta = ApiName.Contains("beta") Or ApiName.Contains("alpha")
+            IsBeta = ApiName.Contains("beta") OrElse ApiName.Contains("alpha")
             If ApiName.Contains("1.20.1") Then '1.20.1-47.1.99
                 VersionName = ApiName.Replace("1.20.1-", "")
                 Version = New Version("19." & VersionName)


### PR DESCRIPTION
现在名字中含 `beta` 和 `alpha` 都会被认为是测试版
~~鬼知道为啥 NeoForge 改了命名方式~~

Resolved https://github.com/Meloong-Git/PCL/issues/7904