### PR TITLE
chore: 更换杂志主页链接

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -100,7 +100,7 @@ Public Class PageLaunchRight
                         Url = "https://files.mcimirror.top/PCL"
                     Case 11
                         Log("[Page] 主页预设：杂志主页")
-                        Url = "https://pclhomeplazaoss.lingyunawa.top:26994/d/Homepages/Ext1nguisher/Custom.xaml"
+                        Url = "http://118.195.192.193:26995/d/magazine-homepage-pcl/Custom.xaml"
                     Case 12
                         Log("[Page] 主页预设：PCL GitHub 仪表盘")
                         Url = "https://ddf.pcl-community.org/Custom.xaml"


### PR DESCRIPTION
issue #8180

另外，你们在责怪我只开issue不开PR的时候有没有考虑过是我当时：
- 在除夕夜发现 HPoP 炸了
- 在除夕夜第一次学习部署 Openlist 
- 在除夕夜测测bug
- 在除夕夜发现我的杂志主页构建器里面的“历史上的今天”部分因为没有对特殊字符转义而爆炸了
- 在除夕夜熬夜迁徙，并被家长骂沉迷电脑
- 在除夕夜在PageSetupUI里面翻了个底朝天，也没找到主页链接在哪（后面发现存在`PageLaunchRight`里）
- 在除夕夜发现我即使做了这一切，在龙猫合并之前我的主页仍然没办法正常工作

请别责怪我了吧。