### PR TITLE
 fix(ModSecret): 修复使用JAVA7及更早版本时，未设置永久代内存导致游戏频繁内存溢出崩溃的问题

### DIFF
--- a/Plain Craft Launcher 2/Modules/ModSecret.vb
+++ b/Plain Craft Launcher 2/Modules/ModSecret.vb
@@ -69,6 +69,17 @@ Friend Module ModSecret
         DataList.Add("-Xmn" & Math.Floor(PageInstanceSetup.GetRam(McInstanceSelected) * 1024 * 0.15) & "m")
         DataList.Add("-Xmx" & Math.Floor(PageInstanceSetup.GetRam(McInstanceSelected) * 1024) & "m")
         If Not DataList.Any(Function(d) d.Contains("-Dlog4j2.formatMsgNoLookups=true")) Then DataList.Add("-Dlog4j2.formatMsgNoLookups=true")
+        
+        '为 Java 7 及更早版本自动添加永久代内存参数
+        If McLaunchJavaSelected.MajorVersion <= 7 Then
+            If Not DataList.Any(Function(d) d.Contains("-XX:PermSize=") OrElse d.Contains("-XX:MaxPermSize=")) Then
+                DataList.Add("-XX:PermSize=256m")
+                DataList.Add("-XX:MaxPermSize=512m")
+                McLaunchLog("检测到 Java " & McLaunchJavaSelected.MajorVersion & "，已自动添加永久代内存参数")
+            Else
+                McLaunchLog("检测到 Java " & McLaunchJavaSelected.MajorVersion & "，用户已自定义永久代参数，跳过自动添加")
+            End If
+        End If
     End Sub
 
 #End Region


### PR DESCRIPTION
Java 7 及更早版本使用永久代 (PermGen)​ 存储类元数据，其大小固定（默认约64-128MB），而往后的 Java 8 用元空间 (Metaspace)​ 替代了 PermGen，可自动扩展。

在使用Java7游玩老版本怀旧时，频繁出现"java.lang.OutOfMemoryError: PermGen space"错误致客户端崩溃。

该PR永久修复了此问题，当检测到用户选择了老版本Java时，如果用户未指定这个参数，自动添加了PermGen参数，扩充预分配的内存额度。