### PR TITLE
fix(java): 补充 SDKMAN 安装的 Java 自动搜索

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModJava.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModJava.vb
@@ -521,6 +521,8 @@ NoUserJava:
             Next
             '查找 .jdks 文件夹中的 Java
             JavaSearchFolder(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) & "\.jdks\", JavaPreList, False, True)
+            '查找 SDKMAN 安装目录中的 Java
+            JavaSearchFolder(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) & "\.sdkman\candidates\java\", JavaPreList, False, True)
             '查找 APPDATA 文件夹中的 Java
             JavaSearchFolder(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) & "\", JavaPreList, False)
             JavaSearchFolder(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) & "\", JavaPreList, False)


### PR DESCRIPTION
在 Java 自动搜索流程中加入对用户目录下
.sdkman/candidates/java 及其 current 子目录的扫描，
以支持通过 Git Bash + SDKMAN 在 Windows 上安装的 Java。