### PR TITLE
fix(download): 未适配 Neoforge 新版本命名规则导致找不到 26.1 匹配的 Neoforge

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModDownload.vb
@@ -858,7 +858,7 @@
                 VersionName = ApiName
                 Version = New Version(ApiName.BeforeFirst("-"))
                 If Version.Major >= 24 Then
-                    Inherit = Version.ToString.Replace(".0", "")
+                    Inherit = Version.Major & "." & Version.Minor
                 Else
                     Inherit = "1." & Version.Major & If(Version.Minor > 0, "." & Version.Minor, "")
                 End If


### PR DESCRIPTION
close #8357 