### PR TITLE
refactor(launch): 根据 LWJGL 版本判断是否使用 LWJGL Unsafe Agent

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1330,6 +1330,23 @@ Retry:
 
 #End Region
 
+#Region "获取 LWJGL 版本"
+    Private Function McLaunchGetLwjglVersion(Mc As McInstance) As String
+        For Each library As McLibToken In McLibListGet(Mc, False)
+            If String.IsNullOrWhiteSpace(library.OriginalName) Then Continue For
+
+            Dim parts = library.OriginalName.Split(":"c)
+            If parts.Length >= 3 AndAlso
+               parts(0).Equals("org.lwjgl", StringComparison.OrdinalIgnoreCase) AndAlso
+               parts(1).Equals("lwjgl", StringComparison.OrdinalIgnoreCase) Then
+                Return parts(2)
+            End If
+        Next
+
+        Return Nothing
+    End Function
+#End Region
+
 #Region "启动参数"
     Private McLaunchArgument As String
 
@@ -1447,7 +1464,7 @@ NextInstance:
         'LUA
         Dim UseLUA As Boolean =
             Not Settings.Get("LaunchAdvanceDisableLUA") AndAlso Not Settings.Get("VersionAdvanceDisableLUA", McInstanceSelected) AndAlso
-            McLaunchJavaSelected.MajorVersion >= 25 AndAlso McInstanceSelected.Version.Drop >= 261
+            McLaunchGetLwjglVersion(McInstanceSelected) = "3.4.1"
         If UseLUA Then Args.Add($"-javaagent:""{ExtractPatch("LUA")}""")
         McLaunchLog("使用 LUA：" & UseLUA)
 


### PR DESCRIPTION
本 PR 将原本根据 Minecraft 与 Java 版本判断是否应用 LWJGL Unsafe Agent 的逻辑更改为了根据 LWJGL 版本判断，理论上这会减少出现问题时的影响范围、并且能够支持所有可能存在问题的 MC 实例（例如 26.1-snapshot-8 与其他启动器安装的 Cleanroom 实例）。

<img width="1169" height="732" alt="image" src="https://github.com/user-attachments/assets/c19cbbce-a6a9-48e3-ad8c-7ffcb1c581f5" />

HMCL 与 PCL CE 均通过判断 LWJGL 版本决定是否使用 LUA，此次修改将逻辑与其对齐以防出现可能的意外行为。

相关代码来自 PCL CE，现将此修复重新贡献回上游。

https://github.com/PCL-Community/PCL-CE/commit/44c2d307e877701c582f7258bbe777fb646817f0