### PR TITLE
feat: 用户可以在下载社区资源时一键填充版本信息

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml
@@ -64,6 +64,7 @@
                     </Grid.ColumnDefinitions>
                     <local:MyButton x:Name="BtnSearchRun" Text="搜索" MinWidth="140" Padding="13,0" Margin="0,0,20,0" ColorType="Highlight" />
                     <local:MyButton x:Name="BtnSearchReset" Text="重置条件" MinWidth="140" Padding="13,0" Margin="0,0,20,0" Grid.Column="1" />
+                    <local:MyButton x:Name="BtnSearchMatch" Text="适配当前版本" MinWidth="140" Padding="13,0" Margin="0,0,20,0" Grid.Column="2" />
                     <local:MyButton x:Name="BtnSearchInstallModPack" Text="安装已有整合包" MinWidth="140" Padding="13,0" Margin="0,0,20,0" Grid.Column="2"
                                     ToolTip="在当前选择的 Minecraft 文件夹下安装整合包" ToolTipService.HorizontalOffset="-55" ToolTipService.VerticalOffset="5" />
                 </Grid>

--- a/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Comp/PageComp.xaml.vb
@@ -55,6 +55,7 @@ Public Class PageComp
         Set(Value As CompType)
             If _Type = Value Then Return
             _Type = Value
+            BtnSearchMatch.Visibility = If(Value = CompType.ModPack, Visibility.Collapsed, Visibility.Visible)
             BtnSearchInstallModPack.Visibility = If(Value = CompType.ModPack, Visibility.Visible, Visibility.Collapsed)
         End Set
     End Property
@@ -227,6 +228,25 @@ Public Class PageComp
     End Sub
     Private Sub EnterTrigger(sender As Object, e As KeyEventArgs) Handles TextSearchName.KeyDown, TextSearchVersion.KeyDown
         If e.Key = Key.Enter Then StartNewSearch()
+    End Sub
+
+    '适配按钮
+    Private Sub MatchFilter() Handles BtnSearchMatch.Click
+        If McInstanceSelected Is Nothing Then '确保用户选择了版本
+            Hint("请先选择一个版本！", HintType.Red)
+            Return
+        End If
+        If (PageType = CompType.Mod Or PageType = CompType.Shader) And Not McInstanceSelected.Modable Then '确认用户在下载 Mod 相关资源时选择了可使用 Mod 的版本
+            Hint("该版本不可使用 Mod！", HintType.Red)
+            Return
+        End If
+        TextSearchVersion.Text = McInstanceSelected.Version.VanillaName
+        Dim LoaderType As Integer = 0
+        If McInstanceSelected.Version.HasForge Then LoaderType = 1
+        If McInstanceSelected.Version.HasNeoForge Then LoaderType = 2
+        If McInstanceSelected.Version.HasFabric Then LoaderType = 3
+        ComboSearchLoader.SelectedIndex = LoaderType
+        Loader.LastFinishedTime = 0 '要求强制重新开始
     End Sub
 
     '重置按钮


### PR DESCRIPTION
<img width="1350" height="825" alt="屏幕截图 2026-04-05 194107" src="https://github.com/user-attachments/assets/43a888b8-b08e-4b3f-b96c-23171a5c2599" />

添加了一个按钮，可以填充当前选中的版本的信息到文本框。

在整合包下载页面不显示。

在 Mod 和光影包下载页面需要选中一个可安装 Mod 的版本。