### PR TITLE
[codex] add cli modpack import

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -53,6 +53,13 @@ Public Class Application
                     End If
                 End If
             End If
+            'CLI 整合包导入
+            For Index As Integer = 0 To e.Args.Length - 1
+                If e.Args(Index).Equals("--import", StringComparison.OrdinalIgnoreCase) AndAlso Index + 1 < e.Args.Length Then
+                    Properties("PendingImportFile") = e.Args(Index + 1).Trim(""""c)
+                    Exit For
+                End If
+            Next
             '初始化文件结构
             Directory.CreateDirectory(Path & "PCL\Pictures")
             Directory.CreateDirectory(Path & "PCL\Musics")

--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -456,6 +456,26 @@ Public Class FormMain
             Telemetry("启动")
         End Sub, "初始化", ThreadPriority.Lowest)
 
+        'CLI 整合包导入
+        If Application.Current.Properties.Contains("PendingImportFile") Then
+            Dim ImportPath As String = CStr(Application.Current.Properties("PendingImportFile"))
+            Application.Current.Properties.Remove("PendingImportFile")
+            If IO.File.Exists(ImportPath) Then
+                RunInNewThread(
+                Sub()
+                    Try
+                        Thread.Sleep(500)
+                        ModpackInstall(ImportPath)
+                    Catch ex As CancelledException
+                    Catch ex As Exception
+                        Log(ex, "CLI 导入整合包失败", LogLevel.Msgbox)
+                    End Try
+                End Sub, "CLI 整合包导入")
+            Else
+                Hint("CLI 导入失败：文件不存在 - " & ImportPath, HintType.Red)
+            End If
+        End If
+
         Log("[Start] 第三阶段加载用时：" & GetTimeMs() - ApplicationStartTick & " ms")
     End Sub
     '根据打开次数触发的事件


### PR DESCRIPTION
﻿## Summary
- add parsing for `--import <path>` during PCL startup
- defer the import until the main window has loaded, then call the existing `ModpackInstall` flow on a background thread
- show an error hint when the requested modpack file does not exist

## Validation
- Built locally with MSBuild Release / Any CPU after installing the .NET Framework 4.6.2 Developer Pack
- Build completed with 0 errors and existing `ModMusic.vb` obsolete API warnings only
