### PR TITLE
chore: remove protocol set

### DIFF
--- a/Plain Craft Launcher 2/Application.xaml.vb
+++ b/Plain Craft Launcher 2/Application.xaml.vb
@@ -99,7 +99,6 @@ WaitRetry:
             ToolTipService.VerticalOffsetProperty.OverrideMetadata(GetType(DependencyObject), New FrameworkPropertyMetadata(4.0))
             '设置网络配置默认值
             ServicePointManager.Expect100Continue = False
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3 Or SecurityProtocolType.Tls Or SecurityProtocolType.Tls11 Or SecurityProtocolType.Tls12
             ServicePointManager.DefaultConnectionLimit = 10000
             ServicePointManager.UseNagleAlgorithm = False
             ServicePointManager.EnableDnsRoundRobin = True


### PR DESCRIPTION
移除了对 SecurityProtocol 的设定，让 Schannel 的行为更贴近自动选择

## 原因

PCL 使用的所有 API 均不支持 TLS v1.2- 的协议版本，而且几乎没有哪家 CDN(Amazon、Cloudflare、Microsoft Azure、Tencent、Aliyun) 不支持 TLS v1.2+，所以使用 SecurityProtocol 进行向下兼容并没有任何意义，反而主动禁用了更安全的 TLS v1.3 协议

## 参考资料

https://myssl.com/piston-meta.mojang.com?domain=piston-meta.mojang.com&port=443&status=success
https://myssl.com/api.minecraftservices.com?domain=api.minecraftservices.com&status=success
https://www.ssllabs.com/ssltest/analyze.html?d=bmclapi2.bangbang93.com
https://learn.microsoft.com/en-us/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-
https://learn.microsoft.com/zh-cn/dotnet/fundamentals/code-analysis/quality-rules/ca5386