### PR TITLE
fix: 修复启动取消后MC进程后台残留

### DIFF
--- a/Plain Craft Launcher 2/FormMain.xaml.vb
+++ b/Plain Craft Launcher 2/FormMain.xaml.vb
@@ -1670,7 +1670,15 @@ Public Class FormMain
     '关闭 Minecraft
     Public Sub BtnExtraShutdown_Click() Handles BtnExtraShutdown.Click
         Try
-            If McLaunchLoaderReal IsNot Nothing Then McLaunchLoaderReal.Interrupt()
+            Try
+                If McLaunchLoaderReal IsNot Nothing Then McLaunchLoaderReal.Interrupt()
+                For Each Watcher In McWatcherList
+                    Watcher.Kill()
+                Next
+                Hint("已取消启动并终止游戏进程", HintType.Green)
+            Catch ex As Exception
+                Log(ex, "取消启动时终止游戏进程失败", LogLevel.Feedback)
+            End Try
             For Each Watcher In McWatcherList
                 Watcher.Kill()
             Next


### PR DESCRIPTION
 #8140 **问题描述**
当用户在 PCL2 中点击“启动游戏”后，若在启动过程中取消操作，Java 进程（MC 进程）会在后台残留，无法被正常终止，导致占用系统资源，且无法再次正常启动游戏。

 **解决方案**
1.  在启动流程中，为 MC 进程添加明确的进程句柄管理与取消回调逻辑。
2.  当用户取消启动时，主动调用进程终止接口，并等待进程完全退出，确保资源被释放。
3.  增加异常处理，防止因进程句柄释放失败导致的内存泄漏或后续启动异常。

 **验证情况**
-  多次测试“启动中取消”操作，MC 进程均能被完全终止，无后台残留。
-  正常启动/关闭游戏功能不受影响，启动流程保持稳定。
-  兼容不同版本 Java 环境与系统_（Windows）_。
关联 Issue
Fixes #8140 