### PR TITLE
fix(export): 强制确保导出文件包含 .zip 扩展名

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceExport.xaml.vb
@@ -426,6 +426,10 @@ Public Class PageInstanceExport
             If Not CheckOptionsPcl.Checked Then Extensions.Add("Modrinth 整合包文件(*.mrpack)|*.mrpack")
             PackPath = SelectSaveFile("选择导出位置",
                 PackName & If(String.IsNullOrEmpty(TextExportVersion.Text), "", " " & TextExportVersion.Text), Extensions.Join("|"))
+            ' 强制确保文件扩展名正确（修复 Windows 将版本号中的 .数字 识别为扩展名的问题）
+            If Not String.IsNullOrEmpty(PackPath) Then
+                If Not PackPath.EndsWithF(".zip") AndAlso Not PackPath.EndsWithF(".mrpack") Then PackPath &= ".zip"
+            End If
             Log($"[Export] 手动指定的导出路径：{PackPath}")
         End If
         If String.IsNullOrEmpty(PackPath) Then Return


### PR DESCRIPTION
## 修复内容
修复导出整合包时生成的文件缺少 `.zip` 扩展名的问题。

## 根因
Windows 将文件名中的 `.数字`（如 `1.21.4` 中的 `.4`）识别为已有文件扩展名（
`HKEY_CLASSES_ROOT` 注册表项），导致 `SaveFileDialog` 的 `AddExtension` 失效，
不追加 `.zip` 后缀。

## 修复方式
在 `SelectSaveFile` 返回后，检查路径是否以 `.zip` 或 `.mrpack` 结尾。
若都没有，则强制追加 `.zip` 后缀。共 4 行新增。

## 测试
1. 进入一个 Fabric 版本（如 1.21.4）
2. 导出 → 勾选"包含 PCL 启动器程序"和"仅从 Modrinth 下载资源文件"
3. 保存文件 → 确认生成路径以 `.zip` 结尾

Closes #8214