### PR TITLE
fix(cape): 复用登录信息导致无法修改披风

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -535,10 +535,22 @@ NextInner:
         Data.Progress = 0.05
         '检查是否已经登录完成
         Dim ExpiresAt = Settings.Get(Of Long)("CacheMsV2Expires")
+
         If Not Data.IsForceRestarting AndAlso '不要求强行重启
            ExpiresAt > 0 AndAlso ExpiresAt > GetUnixTimestampUtc() Then 'AccessToken 尚未过期
-            Data.Output = New McLoginResult With
-                {.AccessToken = Input.AccessToken, .Name = Input.UserName, .Uuid = Input.Uuid, .Type = "Microsoft", .ClientToken = Input.Uuid, .ProfileJson = Input.ProfileJson}
+            'https://github.com/Meloong-Git/PCL/issues/8638
+            '如果是程序刚启动时调用的登录，此时加载器的状态为 Waiting，GetLoginData 函数会返回不带 ProfileJson 的数据作为输入
+            If String.IsNullOrEmpty(Input.ProfileJson) Then
+                Input = PageLoginMsSkin.GetLoginData(True)
+            End If
+            Data.Output = New McLoginResult With {
+                .AccessToken = Input.AccessToken,
+                .Name = Input.UserName,
+                .Uuid = Input.Uuid,
+                .Type = "Microsoft",
+                .ClientToken = Input.Uuid,
+                .ProfileJson = Input.ProfileJson
+            }
             McLaunchLog("无需登录，AccessToken 尚未过期")
             GoTo SkipLogin
         End If

--- a/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/MySkin.xaml.vb
@@ -256,7 +256,7 @@ Retry:
                         Next
                         SelectedIndex = MyMsgBoxSelect(SelectionControl, "选择披风", "确定", "取消")
                     Catch ex As Exception
-                        Logger.Error(ex, "获取玩家皮肤列表失败")
+                        Logger.Error(ex, "获取玩家披风列表失败")
                     End Try
                 End Sub)
                 If SelectedIndex Is Nothing Then Return

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginMsSkin.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLoginMsSkin.xaml.vb
@@ -18,8 +18,8 @@
     ''' <summary>
     ''' 获取当前页面的登录信息。
     ''' </summary>
-    Public Shared Function GetLoginData() As McLoginMs
-        If McLoginMsLoader.State = LoadState.Finished Then
+    Public Shared Function GetLoginData(Optional IgnoreState As Boolean = False) As McLoginMs
+        If IgnoreState OrElse McLoginMsLoader.State = LoadState.Finished Then
             Return New McLoginMs With {.OAuthRefreshToken = Settings.Get(Of String)("CacheMsV2OAuthRefresh"), .UserName = Settings.Get(Of String)("CacheMsV2Name"), .AccessToken = Settings.Get(Of String)("CacheMsV2Access"), .Uuid = Settings.Get(Of String)("CacheMsV2Uuid"), .ProfileJson = Settings.Get(Of String)("CacheMsV2ProfileJson")}
         Else
             Return New McLoginMs With {.OAuthRefreshToken = Settings.Get(Of String)("CacheMsV2OAuthRefresh"), .UserName = Settings.Get(Of String)("CacheMsV2Name")}


### PR DESCRIPTION
Resolved #8638

顺带纠正了修改披风失败也会显示成修改皮肤失败