### PR TITLE
chore: 在“Minecraft 崩溃”的 issue 模板中添加 PCL 汉医堂的链接

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug1.yml
+++ b/.github/ISSUE_TEMPLATE/bug1.yml
@@ -8,7 +8,7 @@ body:
     label: "检查项"
     description: "请逐个检查下列项目，并勾选确认。"
     options:
-    - label: "**我所启动的游戏不是整合包，且未安装任何 Mod。** 安装 Mod 后的游戏崩溃基本不是 PCL 的原因，请 **不要** 提交反馈。你可以前往 [PCL 汉医堂](https://qm.qq.com/q/JJTzwEAmcw)等群聊或论坛进行求助，但这里并不是你求助的地方。"
+    - label: "**我所启动的游戏不是整合包，且未安装任何 Mod。** 安装 Mod 后的游戏崩溃基本不是 PCL 的原因，请 **不要** 提交反馈。你可以前往 [PCL 汉医堂](https://qm.qq.com/q/JJTzwEAmcw) 等群聊或论坛进行求助，但这里并不是你求助的地方。"
       required: false
     - label: "**我已尝试使用 HMCL 启动，HMCL 没有出现问题。** 如果 HMCL 也无法启动就不是 PCL 导致的问题，请 **不要** 提交反馈。[下载 HMCL](https://hmcl.huangyuhui.net/download)"
       required: true

--- a/.github/ISSUE_TEMPLATE/bug1.yml
+++ b/.github/ISSUE_TEMPLATE/bug1.yml
@@ -8,7 +8,7 @@ body:
     label: "检查项"
     description: "请逐个检查下列项目，并勾选确认。"
     options:
-    - label: "**我所启动的游戏不是整合包，且未安装任何 Mod。** 安装 Mod 后的游戏崩溃基本不是 PCL 的原因，请 **不要** 提交反馈。你可以在论坛或社区找人求助，但这里并不是你求助的地方。"
+    - label: "**我所启动的游戏不是整合包，且未安装任何 Mod。** 安装 Mod 后的游戏崩溃基本不是 PCL 的原因，请 **不要** 提交反馈。你可以前往 [PCL 汉医堂](https://qm.qq.com/q/JJTzwEAmcw)等群聊或论坛进行求助，但这里并不是你求助的地方。"
       required: false
     - label: "**我已尝试使用 HMCL 启动，HMCL 没有出现问题。** 如果 HMCL 也无法启动就不是 PCL 导致的问题，请 **不要** 提交反馈。[下载 HMCL](https://hmcl.huangyuhui.net/download)"
       required: true


### PR DESCRIPTION
正确引导想要在 issues 求助游戏崩溃的玩家加入 PCL 汉医堂，避免玩家错误提交到 issues 导致解决效率极低
<img width="1555" height="624" alt="image" src="https://github.com/user-attachments/assets/953e1ddf-3eab-4231-9e63-8bae2e66d81a" />
