### PR TITLE
fix(instance): 避免重载版本独立设置时下拉框回退导致数组越界

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
@@ -450,7 +450,7 @@ PreFin:
                     "如果你不会迁移存档，不建议修改这项设置！",
                     "警告", "我知道我在做什么", "取消", IsWarn:=True) = 2 Then
             IsReverting = True
-            ComboArgumentIndieV2.SelectedItem = e.RemovedItems(0)
+            If e.RemovedItems.Count > 0 Then ComboArgumentIndieV2.SelectedItem = e.RemovedItems(0)
             IsReverting = False
         End If
         '实际应用设置


### PR DESCRIPTION
重载版本独立设置时会设置 ComboArgumentIndieV2.SelectedIndex 并触发 SelectionChanged。若该下拉框此前无选中项（SelectedIndex 为 -1），
则 e.RemovedItems 为空，原代码直接访问 e.RemovedItems(0) 进行选择回退， 会抛出 IndexOutOfRangeException，被 Reload() 捕获并记录为
“重载版本独立设置时出错：索引超出了数组界限”。

仅在 e.RemovedItems.Count > 0 时才回退选择，避免空集合越界。

close #7085