### PR TITLE
fix: MyLoading 网络异常时错误文本格式化有误

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyLoading.xaml.vb
+++ b/Plain Craft Launcher 2/Controls/MyLoading.xaml.vb
@@ -76,8 +76,7 @@ Public Class MyLoading
                     If Ex Is Nothing Then
                         LabText.Text = "未知错误"
                     Else
-                        Ex = Ex.RootException()
-                        LabText.Text = If(Ex.IsBadNetwork(), "网络环境不佳，请稍后再试，或使用 VPN 改善网络环境", Ex.Message)
+                        LabText.Text = If(Ex.IsBadNetwork(), "网络环境不佳，请稍后再试，或使用 VPN 改善网络环境", Ex.GetDisplay(False))
                     End If
                 Else
                     LabText.Text = TextError


### PR DESCRIPTION
## Summary

修复 #8712。`MyLoading.RefreshText()` 中 error 分支的两个问题：

1. `IsBadNetwork()` 原本对 `RootException()` 调用——根异常无 `InnerException`，`Flatten()` 只返回单个节点，无法检测链中的网络异常类型，导致漏判。改为对原始异常调用。

2. fallback 文本原为 `RootException().Message`（底层异常的原始技术信息），改用 `GetDisplay(False)` 返回单行用户友好描述。