### PR TITLE
修复删除游戏文件夹确认弹窗按钮重复

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
@@ -296,7 +296,7 @@ Public Class PageSelectLeft
         Dim DeleteText As String = If((Target.Type = McFolder.Types.Vanilla OrElse Target.Type = McFolder.Types.RenamedVanilla) AndAlso Target.Location = Paths.Base & ".minecraft\" AndAlso McFolderList.IsSingle, "清空", "删除")
         If MyMsgBox("你确定要" & DeleteText & "这个文件夹吗？" & vbCrLf &
                     "目标文件夹：" & Target.Location & vbCrLf & vbCrLf &
-                    "该文件夹中的游戏存档、游戏版本，以及 MC 之外的其他文件，都会永久丢失，不可恢复！", "警告", "取消", "确认", "取消") <> 2 Then Return
+                    "该文件夹中的游戏存档、游戏版本，以及 MC 之外的其他文件，都会永久丢失，不可恢复！", "警告", "确认", "取消") <> 1 Then Return
         If MyMsgBoxInput("删除确认",
                          "该文件夹中的游戏存档、游戏版本，以及 MC 之外的其他文件，都会永久丢失，不可恢复！" & vbCrLf &
                          "目标文件夹：" & Target.Location & vbCrLf & vbCrLf &


### PR DESCRIPTION
## 问题描述

在「版本选择 → 文件夹列表」中删除游戏文件夹时，警告弹窗会同时显示两个“取消”按钮，且主按钮也显示为“取消”。

## 原因

调用 `MyMsgBox` 时依次传入了“取消”“确认”“取消”三个按钮文本，因此弹窗按参数生成了两个“取消”按钮。

## 修改内容

- 将弹窗按钮调整为“确认”和“取消”。
- 移除重复的按钮。
- 同步调整返回值判断，确保只有点击“确认”才会进入二次输入确认。

## 影响

删除流程和二次输入确认保持不变，仅修正首次警告弹窗的按钮文本、数量及对应判断。

## 验证

- [x] Debug 配置构建通过
- [x] Release 配置构建通过
- [x] `git diff --check` 通过

Debug 和 Release 构建均为 0 个错误。构建过程中出现 1 个与本次修改无关的现有不可达代码警告。
