### PR TITLE
chore: 更新杂志主页地址

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -89,7 +89,7 @@ Public Class PageLaunchRight
                         Url = "https://files.mcimirror.top/PCL"
                     Case 11
                         Logger.Info("主页预设：杂志主页")
-                        Url = "http://118.195.192.193:26995/d/magazine-homepage-pcl/Custom.xaml"
+                        Url = "https://gh-proxy.com/https://github.com/CreeperIsASpy/Magazine-Homepage-PCL/raw/main/output/Custom.xaml"
                     Case 12
                         Logger.Info("主页预设：PCL GitHub 仪表盘")
                         Url = "https://ddf.pcl-community.top/Custom.xaml"

--- a/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageLaunch/PageLaunchRight.xaml.vb
@@ -89,7 +89,7 @@ Public Class PageLaunchRight
                         Url = "https://files.mcimirror.top/PCL"
                     Case 11
                         Logger.Info("主页预设：杂志主页")
-                        Url = "https://gh-proxy.com/https://github.com/CreeperIsASpy/Magazine-Homepage-PCL/raw/main/output/Custom.xaml"
+                        Url = "https://gh-proxy.com/https://github.com/Neclyon/Magazine-Homepage-PCL/raw/main/output/Custom.xaml"
                     Case 12
                         Logger.Info("主页预设：PCL GitHub 仪表盘")
                         Url = "https://ddf.pcl-community.top/Custom.xaml"


### PR DESCRIPTION
更新杂志主页源地址。
接下来，<https://gh-proxy.com/https://github.com/Neclyon/Magazine-Homepage-PCL/raw/main/output/Custom.xaml> 将会是杂志主页的永久地址，不会再行更改。