### PR TITLE
issue#9007：优化AccessToken更新策略

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1031,9 +1031,11 @@ Retry:
         End Try
 
         Dim ResultJson As JObject = Result.DeserializeJson()
+        Dim TokenExpiresIn As Integer = Settings.Get("TokenExpiresInCustom") * 3600 + 600
+        TokenExpiresIn = Math.Min(TokenExpiresIn, ResultJson("expires_in").ToObject(Of Integer) - 1200)
         Return (
             ResultJson("access_token").ToString,
-            ResultJson("expires_in").ToObject(Of Integer) + GetUnixTimestampUtc() - 1200) '提前 20 分钟视作过期
+            TokenExpiresIn + GetUnixTimestampUtc())
     End Function
     '微软登录步骤 5：验证微软账号是否持有 MC，这也会刷新 XGP
     Private Sub MsLoginStep5(AccessToken As String)

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -27,6 +27,8 @@
                             <RowDefinition Height="28" />
                             <RowDefinition Height="9" />
                             <RowDefinition Height="28" />
+                            <RowDefinition Height="9" />
+                            <RowDefinition Height="28" />
                         </Grid.RowDefinitions>
                         <TextBlock Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Left" Text="默认版本隔离" Margin="0,0,25,0" />
                         <local:MyComboBox local:SettingService.Key="LaunchArgumentIndieV2" x:Name="ComboArgumentIndieV2"
@@ -104,6 +106,8 @@
                                 </local:MyTextBox.ValidateRules>
                             </local:MyTextBox>
                         </Grid>
+                        <TextBlock VerticalAlignment="Center" Grid.Row="12" HorizontalAlignment="Left" Text="账号令牌有效期" Margin="0,0,25,0" />
+                        <local:MySlider Grid.Row="12" Grid.Column="1" x:Name="SliderTokenExpiresInCustom" local:SettingService.Key="TokenExpiresInCustom" ToolTip="设置账号登录令牌将在多久后失效&#xa;如果设置时间过长，游戏启动一段时间后可能因为令牌过期而无法加入正版服务器&#xa;如果设置时间过短，对于网络不流畅的用户，可能影响每次启动游戏时的体验" MaxValue="24" Value="12"/>
                     </Grid>
                 </StackPanel>
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml
@@ -107,7 +107,7 @@
                             </local:MyTextBox>
                         </Grid>
                         <TextBlock VerticalAlignment="Center" Grid.Row="12" HorizontalAlignment="Left" Text="账号令牌有效期" Margin="0,0,25,0" />
-                        <local:MySlider Grid.Row="12" Grid.Column="1" x:Name="SliderTokenExpiresInCustom" local:SettingService.Key="TokenExpiresInCustom" ToolTip="设置账号登录令牌将在多久后失效&#xa;如果设置时间过长，游戏启动一段时间后可能因为令牌过期而无法加入正版服务器&#xa;如果设置时间过短，对于网络不流畅的用户，可能影响每次启动游戏时的体验" MaxValue="24" Value="12"/>
+                        <local:MySlider Grid.Row="12" Grid.Column="1" x:Name="SliderTokenExpiresInCustom" local:SettingService.Key="TokenExpiresInCustom" ToolTip="设置账号登录令牌将在多久后刷新&#xa;如果设置时间过长，游戏启动一段时间后可能因为令牌过期而无法加入正版服务器&#xa;如果设置时间过短，对于网络不流畅的用户，可能影响每次启动游戏时的体验" MaxValue="24" Value="12"/>
                     </Grid>
                 </StackPanel>
             </local:MyCard>

--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.vb
@@ -15,6 +15,8 @@ Public Class PageSetupLaunch
         Static Reloaded As Boolean = False
         If Reloaded Then Return
         Reloaded = True
+        
+        SliderLoad()
 
         '内存自动刷新
         Dim timer As New Threading.DispatcherTimer With {.Interval = New TimeSpan(0, 0, 0, 1)}
@@ -510,6 +512,17 @@ PreFin:
         McInstanceSelected.Load()
         PageInstanceLeft.Instance = McInstanceSelected
         FrmMain.PageChange(FormMain.PageType.InstanceSetup, FormMain.PageSubType.InstanceSetup)
+    End Sub
+    
+    Private Sub SliderLoad()
+        SliderTokenExpiresInCustom.GetHintText =
+            Function(Value As Integer)
+                If Value = 0 Then
+                    Return "10分钟"
+                Else
+                    Return Value & "小时"
+                End If
+            End Function
     End Sub
 
 End Class

--- a/Plain Craft Launcher 2/Pages/PageSetup/Settings.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/Settings.vb
@@ -113,6 +113,7 @@ Public Class Settings
         New Setting("LinkLatencyMode", 0, Source:=Sources.Registry),
         New Setting("LinkCustomPeer", ""),
         New Setting("LinkEasyTierVersion", -1, Source:=Sources.Registry),
+        New Setting("TokenExpiresInCustom", 12, Source:=Sources.Registry),
         New Setting("ToolHelpChinese", True, Source:=Sources.Registry),
         New Setting("ToolDownloadThread", 63, Source:=Sources.Registry),
         New Setting("ToolDownloadSpeed", 42, Source:=Sources.Registry, OnChanged:=AddressOf ModNet.UpdateNetTaskSpeedLimitHigh),


### PR DESCRIPTION
在设置界面添加了滑动条，允许用户手动调整AccessToken刷新时间。默认12小时。
最短时间为10分钟，最长时间为23小时零40分钟（滑动条显示24小时）。

#9007 