### PR TITLE
fix(launch): 修复旧版 Minecraft 自动进入 IPv6 服务器时参数解析错误

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1482,7 +1482,7 @@ NextInstance:
             Else
                 '老版本
                 Dim ParsedAddress As IPAddress = Nothing
-                If IPAddress.TryParse(Server, ParsedAddress) Then
+                If Not Server.StartsWith("[") AndAlso IPAddress.TryParse(Server, ParsedAddress) Then
                     '不带端口号的 IP 地址
                     Args.Add("--server") : Args.Add(Server)
                     Args.Add("--port") : Args.Add("25565")

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1481,17 +1481,22 @@ NextInstance:
                 Args.Add($"--quickPlayMultiplayer") : Args.Add(Server)
             Else
                 '老版本
-                If Server.StartsWith("[") AndAlso Server.Contains("]") Then
+                Dim ParsedAddress As IPAddress = Nothing
+                If IPAddress.TryParse(Server, ParsedAddress) Then
+                    '不带端口号的 IP 地址
+                    Args.Add("--server") : Args.Add(Server)
+                    Args.Add("--port") : Args.Add("25565")
+                ElseIf Server.StartsWith("[") AndAlso Server.Contains("]") AndAlso IPAddress.TryParse(Server.Substring(1, Server.IndexOf("]"c) - 1), ParsedAddress) Then
                     '带方括号的 IPv6 地址
                     Dim AddressEnd = Server.IndexOf("]"c)
                     Args.Add("--server") : Args.Add(Server.Substring(1, AddressEnd - 1))
                     Args.Add("--port") : Args.Add(If(Server.Length > AddressEnd + 1 AndAlso Server(AddressEnd + 1) = ":"c, Server.Substring(AddressEnd + 2), "25565"))
-                ElseIf Server.IndexOf(":"c) >= 0 AndAlso Server.IndexOf(":"c) = Server.LastIndexOf(":"c) Then
+                ElseIf Server.Contains(":") Then
                     '域名或 IPv4 地址包含端口号
                     Args.Add("--server") : Args.Add(Server.Split(":")(0))
                     Args.Add("--port") : Args.Add(Server.Split(":")(1))
                 Else
-                    '不包含端口号，或为不带方括号的 IPv6 地址
+                    '不包含端口号
                     Args.Add("--server") : Args.Add(Server)
                     Args.Add("--port") : Args.Add("25565")
                 End If

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModLaunch.vb
@@ -1481,12 +1481,17 @@ NextInstance:
                 Args.Add($"--quickPlayMultiplayer") : Args.Add(Server)
             Else
                 '老版本
-                If Server.Contains(":") Then
-                    '包含端口号
+                If Server.StartsWith("[") AndAlso Server.Contains("]") Then
+                    '带方括号的 IPv6 地址
+                    Dim AddressEnd = Server.IndexOf("]"c)
+                    Args.Add("--server") : Args.Add(Server.Substring(1, AddressEnd - 1))
+                    Args.Add("--port") : Args.Add(If(Server.Length > AddressEnd + 1 AndAlso Server(AddressEnd + 1) = ":"c, Server.Substring(AddressEnd + 2), "25565"))
+                ElseIf Server.IndexOf(":"c) >= 0 AndAlso Server.IndexOf(":"c) = Server.LastIndexOf(":"c) Then
+                    '域名或 IPv4 地址包含端口号
                     Args.Add("--server") : Args.Add(Server.Split(":")(0))
                     Args.Add("--port") : Args.Add(Server.Split(":")(1))
                 Else
-                    '不包含端口号
+                    '不包含端口号，或为不带方括号的 IPv6 地址
                     Args.Add("--server") : Args.Add(Server)
                     Args.Add("--port") : Args.Add("25565")
                 End If


### PR DESCRIPTION
## 问题说明

在发布时间不晚于 2023-04-04 的 Minecraft 版本中，PCL 使用
`--server` 和 `--port` 参数实现自动进入服务器。

原有代码只要检测到服务器地址包含 `:`，就直接通过 `Split(":")`
分别取第 1、2 项作为服务器地址和端口。这不适用于自身包含多个冒号的
IPv6 地址。

例如自动进入服务器填写：

```text
2001:db8::1234
```

原有代码会生成：`--server 2001 --port db8`。其中 IPv6 地址被截断，db8 也被错误地作为端口传入。

## 修改内容

按以下规则解析旧版 Minecraft 的自动进入服务器地址：

- [IPv6]:port：去除方括号，分别传入完整 IPv6 地址和指定端口；
- [IPv6]：去除方括号，并使用默认端口 25565；
- 裸 IPv6：保留完整地址，并使用默认端口 25565；
- 域名:port 和 IPv4:port：保持原有行为；
- 不带端口的域名和 IPv4：保持使用默认端口 25565。

改动仅涉及 ModLaunch.vb 中旧版本自动进入服务器的参数构造逻辑。

## 复现步骤

1. 使用 PCL 启动 Minecraft 1.19.4。
2. 在版本设置中启用自动进入服务器。
3. 填入`2001:db8::1234`
4. 启动游戏并检查 LatestLaunch.bat。

修复前：

`--server 2001 --port db8`

<img width="2992" height="1803" alt="图片" src="https://github.com/user-attachments/assets/6cfb4cb9-660f-4fe0-b910-46080241fd98" />

修复后：

`--server 2001:db8::1234 --port 25565`

<img width="2992" height="1804" alt="图片" src="https://github.com/user-attachments/assets/4249cc21-40bf-4ea9-ba64-4f63f7660159" />


原实现无法正确解析 IPv6 地址，包括规范的 [IPv6]:port 形式。本修改支持 [IPv6]:port，并将不带方括号的多冒号输入按不含显式端口的 IPv6 地址处理，使用默认端口 25565。

算是一个比较难触发的bugfix(