### PR TITLE
fix: 修复窗口大小切换时边框显示异常

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSetup/PageSetupLaunch.xaml.vb
@@ -446,6 +446,7 @@ PreFin:
         TextArgumentWindowHeight.Visibility = IsVisibie
         LabArgumentWindowMiddle.Visibility = IsVisibie
         TextArgumentWindowWidth.Visibility = IsVisibie
+        CardArgument.TriggerForceResize()
     End Sub
 
     '可见性选择直接关闭的警告


### PR DESCRIPTION
修复 #9255。

切换启动选项中的窗口大小时，输入框的显示状态会改变，导致启动选项卡片的高度动画与内容布局不同步，过渡过程中出现边框错位。

在更新窗口尺寸控件显示状态后立即强制刷新卡片尺寸，取消旧的高度动画并同步边框与内容布局。
