### PR TITLE
版本选择页支持自定义分类与拖拽排序

### DIFF
--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
@@ -1245,6 +1245,157 @@ ExitDataLoad:
     ''' </summary>
     Public McInstanceList As New Dictionary(Of McInstanceCardType, List(Of McInstance))
 
+    ''' <summary>
+    ''' 用户自定义分类。Key 为分类名（与 <see cref="McCustomCategory.Name"/> 相同，禁止重名）。
+    ''' </summary>
+    Public McCustomCategories As New Dictionary(Of String, McCustomCategory)
+
+    ''' <summary>
+    ''' 用户自定义分类。
+    ''' 一个版本可以同时属于多个自定义分类（与系统自动分类并存）。
+    ''' </summary>
+    Public Class McCustomCategory
+        ''' <summary>分类显示名。必须唯一，用作字典 Key。</summary>
+        Public Name As String = ""
+        ''' <summary>包含的实例名（= 版本文件夹名），顺序敏感，会随拖拽变位。</summary>
+        Public InstanceNames As New List(Of String)
+        ''' <summary>当分类下的实例名对应的版本文件夹不存在时，是否丢弃。</summary>
+        Public Sub TrimMissingInstances(AvailableNames As IEnumerable(Of String))
+            Dim Live = New HashSet(Of String)(AvailableNames)
+            InstanceNames = InstanceNames.Where(Function(n) Live.Contains(n)).ToList()
+        End Sub
+        ''' <summary>分类下是否有任何实例。</summary>
+        Public ReadOnly Property HasInstances As Boolean
+            Get
+                Return InstanceNames IsNot Nothing AndAlso InstanceNames.Count > 0
+            End Get
+        End Property
+    End Class
+
+    ''' <summary>
+    ''' 从指定 .minecraft 文件夹加载自定义分类。读不到则视为空字典。
+    ''' </summary>
+    Public Sub LoadCustomCategories(Folder As String)
+        McCustomCategories.Clear()
+        Try
+            Dim Count As Integer = ReadIni(Folder & "PCL.ini", "CustomCategoryCount", 0)
+            For i = 1 To Count
+                Dim CatName As String = ReadIni(Folder & "PCL.ini", $"CustomCategoryName{i}", "")
+                If String.IsNullOrEmpty(CatName) Then Continue For
+                If McCustomCategories.ContainsKey(CatName) Then Continue For '重名时丢弃后者，避免破坏字典
+                Dim OrderRaw As String = ReadIni(Folder & "PCL.ini", $"CustomCategoryOrder{i}", "")
+                Dim Names As New List(Of String)
+                For Each n As String In OrderRaw.Split(":"c)
+                    If Not String.IsNullOrEmpty(n) Then Names.Add(n)
+                Next
+                '去重并保留顺序
+                Names = Names.Distinct().ToList()
+                McCustomCategories(CatName) = New McCustomCategory With {.Name = CatName, .InstanceNames = Names}
+            Next
+        Catch ex As Exception
+            Logger.Warn(ex, "加载自定义分类失败")
+            McCustomCategories.Clear()
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 将当前自定义分类保存到指定 .minecraft 文件夹。
+    ''' </summary>
+    Public Sub SaveCustomCategories(Folder As String)
+        Try
+            WriteIni(Folder & "PCL.ini", "CustomCategoryCount", McCustomCategories.Count)
+            Dim Index As Integer = 0
+            For Each Pair As KeyValuePair(Of String, McCustomCategory) In McCustomCategories.ToList
+                Index += 1
+                Dim Cat As McCustomCategory = Pair.Value
+                WriteIni(Folder & "PCL.ini", $"CustomCategoryName{Index}", Cat.Name)
+                WriteIni(Folder & "PCL.ini", $"CustomCategoryOrder{Index}", If(Cat.InstanceNames.Count > 0, Cat.InstanceNames.Join(":") & ":", ""))
+            Next
+        Catch ex As Exception
+            Logger.Error(ex, "保存自定义分类失败")
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 在当前 Minecraft 文件夹下新建一个空的自定义分类。返回是否成功（重名时返回 False）。
+    ''' </summary>
+    Public Function CreateCustomCategory(Folder As String, CategoryName As String) As Boolean
+        CategoryName = CategoryName?.Trim()
+        If String.IsNullOrEmpty(CategoryName) Then Return False
+        If McCustomCategories.ContainsKey(CategoryName) Then Return False
+        McCustomCategories(CategoryName) = New McCustomCategory With {.Name = CategoryName}
+        SaveCustomCategories(Folder)
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' 删除一个自定义分类（其下所有实例名关联一并解除）。
+    ''' </summary>
+    Public Function DeleteCustomCategory(Folder As String, CategoryName As String) As Boolean
+        If Not McCustomCategories.ContainsKey(CategoryName) Then Return False
+        McCustomCategories.Remove(CategoryName)
+        SaveCustomCategories(Folder)
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' 重命名一个自定义分类。返回是否成功（重名时返回 False）。
+    ''' </summary>
+    Public Function RenameCustomCategory(Folder As String, OldName As String, NewName As String) As Boolean
+        NewName = NewName?.Trim()
+        If String.IsNullOrEmpty(NewName) Then Return False
+        If OldName = NewName Then Return True
+        If Not McCustomCategories.ContainsKey(OldName) Then Return False
+        If McCustomCategories.ContainsKey(NewName) Then Return False
+        Dim Cat As McCustomCategory = McCustomCategories(OldName)
+        McCustomCategories.Remove(OldName)
+        Cat.Name = NewName
+        McCustomCategories(NewName) = Cat
+        SaveCustomCategories(Folder)
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' 在分类中加入一个版本。已存在则不重复加。返回是否实际修改了数据。
+    ''' </summary>
+    Public Function AddInstanceToCategory(Folder As String, CategoryName As String, InstanceName As String) As Boolean
+        If String.IsNullOrEmpty(InstanceName) Then Return False
+        If Not McCustomCategories.ContainsKey(CategoryName) Then Return False
+        Dim List As List(Of String) = McCustomCategories(CategoryName).InstanceNames
+        If List.Contains(InstanceName) Then Return False
+        List.Add(InstanceName)
+        SaveCustomCategories(Folder)
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' 从分类中移除一个版本。返回是否实际修改了数据。
+    ''' </summary>
+    Public Function RemoveInstanceFromCategory(Folder As String, CategoryName As String, InstanceName As String) As Boolean
+        If Not McCustomCategories.ContainsKey(CategoryName) Then Return False
+        Dim List As List(Of String) = McCustomCategories(CategoryName).InstanceNames
+        If Not List.Contains(InstanceName) Then Return False
+        List.Remove(InstanceName)
+        SaveCustomCategories(Folder)
+        Return True
+    End Function
+
+    ''' <summary>
+    ''' 在自定义分类内调整某个实例的位置（拖拽换位用）。
+    ''' </summary>
+    Public Sub MoveInstanceInCategory(Folder As String, CategoryName As String, SourceIndex As Integer, NewIndex As Integer)
+        If Not McCustomCategories.ContainsKey(CategoryName) Then Return
+        Dim List As List(Of String) = McCustomCategories(CategoryName).InstanceNames
+        If SourceIndex < 0 OrElse SourceIndex >= List.Count Then Return
+        If NewIndex < 0 Then NewIndex = 0
+        If NewIndex >= List.Count Then NewIndex = List.Count - 1
+        If SourceIndex = NewIndex Then Return
+        Dim Item As String = List(SourceIndex)
+        List.RemoveAt(SourceIndex)
+        List.Insert(NewIndex, Item)
+        SaveCustomCategories(Folder)
+    End Sub
+
 #End Region
 
 #Region "版本列表加载"
@@ -1305,6 +1456,15 @@ Reload:
                 McInstanceList = InitMcInstanceListWithoutCache(PathMc)
             End If
             IsFirstMcInstanceListLoad = False
+
+            '加载用户自定义分类（独立于版本列表缓存）
+            LoadCustomCategories(PathMc)
+            '清理分类中已不存在的实例名
+            Dim AvailableNames = McInstanceList.Values.SelectMany(Function(l) l).Select(Function(i) i.Name).ToHashSet()
+            For Each Cat In McCustomCategories.Values.ToList
+                Cat.TrimMissingInstances(AvailableNames)
+            Next
+            SaveCustomCategories(PathMc)
 
             '改变当前选择的版本
 OnLoaded:

--- a/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeft.xaml.vb
@@ -80,6 +80,7 @@ Public Class PageSelectLeft
                                                     ContMenu.IsOpen = True
                                                 End Sub
                 NewItem.Buttons = {NewIconButton}
+                EnableFolderItemDrag(NewItem)
                 FrmSelectLeft.PanList.Children.Add(NewItem)
                 Logger.Info($"有效的 Minecraft 文件夹：{Folder.Name} > {Folder.Location}")
             Next

--- a/Plain Craft Launcher 2/Pages/PageSelectLeftDrag.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectLeftDrag.vb
@@ -1,0 +1,110 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Input
+
+Partial Public Class PageSelectLeft
+
+#Region "拖拽"
+
+    ''' <summary>
+    ''' 拖拽"文件夹列表"中的文件夹项时附带的数据。
+    ''' </summary>
+    Public Class FolderDragData
+        Public SourceLocation As String
+    End Class
+
+    ''' <summary>
+    ''' 为"文件夹列表"中的 <see cref="MyListItem"/> 启用拖拽排序（仅在文件夹项之间有效）。
+    ''' </summary>
+    Public Sub EnableFolderItemDrag(Item As MyListItem)
+        Try
+            '仅当 Tag 是 McFolder 时启用拖拽，避免按钮等其他条目被误触发
+            Dim Folder As McFolder = TryCast(Item.Tag, McFolder)
+            If Folder Is Nothing Then Return
+            Item.AllowDrop = True
+            Dim StartPoint As Point = New Point(0, 0)
+            Dim DragStarted As Boolean = False
+            Dim SrcLocation As String = Folder.Location
+            AddHandler Item.PreviewMouseLeftButtonDown, Sub(s, e)
+                StartPoint = e.GetPosition(Nothing)
+                Dim Src As McFolder = TryCast(Item.Tag, McFolder)
+                SrcLocation = If(Src Is Nothing, "", Src.Location)
+                DragStarted = False
+            End Sub
+            AddHandler Item.PreviewMouseMove, Sub(s, e)
+                Dim SrcItem As MyListItem = CType(s, MyListItem)
+                If DragStarted OrElse e.LeftButton <> MouseButtonState.Pressed Then Return
+                Dim Cur = e.GetPosition(Nothing)
+                If Math.Abs(Cur.X - StartPoint.X) >= SystemParameters.MinimumHorizontalDragDistance OrElse
+                   Math.Abs(Cur.Y - StartPoint.Y) >= SystemParameters.MinimumVerticalDragDistance Then
+                    If String.IsNullOrEmpty(SrcLocation) Then Return
+                    DragStarted = True
+                    Try
+                        Dim Payload As New FolderDragData With {.SourceLocation = SrcLocation}
+                        Dim DataObj As New DataObject(GetType(FolderDragData), Payload)
+                        DragDrop.DoDragDrop(SrcItem, DataObj, DragDropEffects.Move)
+                    Finally
+                        DragStarted = False
+                    End Try
+                End If
+            End Sub
+            AddHandler Item.PreviewDragOver, Sub(s, e)
+                Dim Data = TryCast(e.Data.GetData(GetType(FolderDragData)), FolderDragData)
+                Dim TargetFolder As McFolder = TryCast(Item.Tag, McFolder)
+                If Data IsNot Nothing AndAlso TargetFolder IsNot Nothing AndAlso Data.SourceLocation <> TargetFolder.Location Then
+                    e.Effects = DragDropEffects.Move
+                Else
+                    e.Effects = DragDropEffects.None
+                End If
+                e.Handled = True
+            End Sub
+            AddHandler Item.PreviewDrop, Sub(s, e)
+                Dim Data = TryCast(e.Data.GetData(GetType(FolderDragData)), FolderDragData)
+                If Data Is Nothing Then Return
+                Dim TargetFolder As McFolder = TryCast(Item.Tag, McFolder)
+                If TargetFolder Is Nothing Then Return
+                If Data.SourceLocation = TargetFolder.Location Then Return
+                Try
+                    ReorderFoldersInSetup(Data.SourceLocation, TargetFolder.Location)
+                    Hint("文件夹顺序已调整", HintType.Green)
+                    McFolderListLoader.Start(IsForceRestart:=True)
+                Catch ex As Exception
+                    Logger.Error(ex, "拖拽调整文件夹顺序失败")
+                End Try
+                e.Handled = True
+            End Sub
+        Catch ex As Exception
+            Logger.Warn(ex, "为文件夹项启用拖拽失败")
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 把 Settings("LaunchFolders") 中 <paramref name="SourceLocation"/> 对应的条目
+    ''' 调整到 <paramref name="TargetLocation"/> 对应条目的位置（保留相同 DisplayName）。
+    ''' </summary>
+    Private Shared Sub ReorderFoldersInSetup(SourceLocation As String, TargetLocation As String)
+        Dim RawEntries = Settings.Get(Of String)("LaunchFolders").Split("|"c, StringSplitOptions.RemoveEmptyEntries).ToList()
+        Dim SrcIdx = -1
+        Dim TgtIdx = -1
+        For i = 0 To RawEntries.Count - 1
+            Dim Parts = RawEntries(i).Split(">"c, 2)
+            If Parts.Length < 2 Then Continue For
+            Dim Loc = Parts(1).TrimEnd("\"c) & "\"
+            If String.Equals(Loc, SourceLocation.TrimEnd("\"c) & "\", StringComparison.OrdinalIgnoreCase) Then
+                SrcIdx = i
+            ElseIf String.Equals(Loc, TargetLocation.TrimEnd("\"c) & "\", StringComparison.OrdinalIgnoreCase) Then
+                TgtIdx = i
+            End If
+            If SrcIdx >= 0 AndAlso TgtIdx >= 0 Then Exit For
+        Next
+        If SrcIdx < 0 OrElse TgtIdx < 0 OrElse SrcIdx = TgtIdx Then Return
+        Dim Entry = RawEntries(SrcIdx)
+        RawEntries.RemoveAt(SrcIdx)
+        Dim InsertAt As Integer = Math.Min(TgtIdx, RawEntries.Count)
+        RawEntries.Insert(InsertAt, Entry)
+        Settings.Set("LaunchFolders", RawEntries.Join("|"))
+    End Sub
+
+#End Region
+
+End Class

--- a/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectRight.xaml.vb
@@ -109,6 +109,9 @@ Public Class PageSelectRight
                 PanEmpty.Visibility = Visibility.Collapsed
             End If
 
+            '渲染用户自定义分类卡片与新建分类按钮（在系统分类卡之后）
+            RenderCustomCategoryCards()
+
         Catch ex As Exception
             Logger.Error(ex, "将版本列表转换显示时失败")
         End Try

--- a/Plain Craft Launcher 2/Pages/PageSelectRightCategory.vb
+++ b/Plain Craft Launcher 2/Pages/PageSelectRightCategory.vb
@@ -1,0 +1,338 @@
+Imports System.Windows
+Imports System.Windows.Controls
+Imports System.Windows.Input
+Imports System.Windows.Media
+Imports System.Collections.ObjectModel
+
+Partial Public Class PageSelectRight
+
+#Region "渲染"
+
+    ''' <summary>
+    ''' 在主 McInstanceListUI 的最后阶段调用，用于渲染所有用户自定义分类卡片和"新建分类"按钮。
+    ''' </summary>
+    Public Sub RenderCustomCategoryCards()
+        If McCustomCategories Is Nothing Then Return
+        Try
+            '清理已不属于现有版本文件夹的实例名映射
+            Dim AllInstances = McInstanceList.Values.SelectMany(Function(l) l).ToList()
+            Dim NameToInstance As New Dictionary(Of String, McInstance)
+            For Each Inst In AllInstances
+                If Not NameToInstance.ContainsKey(Inst.Name) Then NameToInstance(Inst.Name) = Inst
+            Next
+            Dim HasTrimmed As Boolean = False
+            For Each Cat In McCustomCategories.Values.ToList
+                Dim Trimmed = Cat.InstanceNames.Where(Function(n) NameToInstance.ContainsKey(n)).ToList()
+                If Trimmed.Count <> Cat.InstanceNames.Count Then
+                    Cat.InstanceNames = Trimmed
+                    HasTrimmed = True
+                End If
+            Next
+            If HasTrimmed Then SaveCustomCategories(McFolderSelected)
+
+            '按字典顺序遍历，便于稳定显示
+            For Each Cat In McCustomCategories.Values.OrderBy(Function(c) c.Name).ToList()
+                Dim InstList As New List(Of McInstance)
+                For Each Iname In Cat.InstanceNames.ToList()
+                    If NameToInstance.ContainsKey(Iname) Then InstList.Add(NameToInstance(Iname))
+                Next
+
+                '若分类已空，跳过渲染
+                If Not InstList.Any Then Continue For
+
+                '构造卡片
+                Dim Card As New MyCard With {
+                    .Title = Cat.Name & " (" & InstList.Count & ")",
+                    .Margin = New Thickness(0, 0, 0, 15),
+                    .SwapType = 0
+                }
+                Dim StackInner As New StackPanel With {
+                    .Margin = New Thickness(20, MyCard.SwapedHeight, 18, 0),
+                    .VerticalAlignment = VerticalAlignment.Top,
+                    .RenderTransform = New TranslateTransform(0, 0),
+                    .Tag = Cat.Name
+                }
+                Card.Children.Add(StackInner)
+                Card.SwapControl = StackInner
+                AddCustomCategoryCardContextMenu(Card, Cat.Name)
+                PanMain.Children.Add(Card)
+                '让卡片以展开状态开始，并初始化占位
+                MyCard.StackInstall(StackInner, 0, Card.Title)
+
+                '添加实例项
+                For Each Inst In InstList
+                    Dim Item As New MyListItem With {
+                        .IsScaleAnimationEnabled = False,
+                        .Type = MyListItem.CheckType.Clickable,
+                        .MinPaddingRight = 30,
+                        .Title = Inst.Name,
+                        .Info = Inst.Info,
+                        .Logo = Inst.Logo,
+                        .Height = 42,
+                        .Tag = Inst
+                    }
+                    AddHandler Item.Click, AddressOf Item_Click
+                    McInstanceListContent(Item, Nothing)
+                    '为自定义分类项额外加一个"从本分类移除"按钮
+                    Dim BtnRemoveFromCat As New MyIconButton With {
+                        .Logo = IconDataMinus,
+                        .LogoScale = 0.85,
+                        .ToolTip = $"从自定义分类 {Cat.Name} 中移除"
+                    }
+                    AddHandler BtnRemoveFromCat.Click, Sub() PromptRemoveInstanceFromCategory(Cat.Name, Inst)
+                    Item.Buttons = Item.Buttons.Concat({BtnRemoveFromCat}).ToArray()
+                    StackInner.Children.Add(Item)
+                    '为该项启用自定义分类卡内的拖拽排序
+                    EnableCustomCategoryItemDrag(Item, Cat.Name)
+                Next
+
+                '添加"加入版本到此分类"入口
+                Dim AddItem As New MyListItem With {
+                    .IsScaleAnimationEnabled = False,
+                    .Type = MyListItem.CheckType.Clickable,
+                    .Title = $"+   把版本加入 {Cat.Name}",
+                    .Height = 34,
+                    .ToolTip = "将一个仍未归入此分类的版本加入此分类"
+                }
+                AddHandler AddItem.Click, Sub() AddInstanceToCategoryPicker(Cat.Name, InstList, NameToInstance)
+                StackInner.Children.Add(AddItem)
+            Next
+
+            '"新建分类"按钮（在所有自定义分类卡之后）
+            Dim NewCategoryItem As New MyListItem With {
+                .IsScaleAnimationEnabled = False,
+                .Type = MyListItem.CheckType.Clickable,
+                .Title = "+   新建分类",
+                .Height = 34,
+                .ToolTip = "新建一个用于对版本进行自定义分类的分类卡"
+            }
+            AddHandler NewCategoryItem.Click, Sub() PromptCreateCustomCategory()
+            PanMain.Children.Add(NewCategoryItem)
+        Catch ex As Exception
+            Logger.Error(ex, "渲染自定义分类卡片失败")
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 为自定义分类卡片自身附加右键菜单（重命名 / 删除）。
+    ''' 实现为在每次 Build 时附加 Tag，菜单在卡片标题点击时触发。
+    ''' 由于 MyCard 没有内置标题右键，此处改用卡片顶部附加一个 MyIconButton 来弹出菜单。
+    ''' </summary>
+    Private Sub AddCustomCategoryCardContextMenu(Card As MyCard, CategoryName As String)
+        Try
+            Dim Menu As New ContextMenu
+            Dim RenameItem As New MyMenuItem With {.Header = "重命名分类", Icon = "M53.2929,21.2929L54.7071,22.7071C56.4645,24.4645 56.4645,27.3137 54.7071,29.0711L52.2323,31.5459L44.4541,23.7677L46.9289,21.2929C48.6863,19.5355 51.5355,19.5355 53.2929,21.2929 Z M31.7262,52.052L23.948,44.2738L43.0399,25.182L50.818,32.9601L31.7262,52.052 Z M23.2409,47.1023L28.8977,52.7591L21.0463,54.9537L23.2409,47.1023 Z"}
+            AddHandler RenameItem.Click, Sub() PromptRenameCustomCategory(CategoryName)
+            Menu.Items.Add(RenameItem)
+            Dim DeleteItem As New MyMenuItem With {.Header = "删除分类", Icon = "M26.9166,22.1667L37.9999,33.25L49.0832,22.1668L53.8332,26.9168L42.7499,38L53.8332,49.0834L49.0833,53.8334L37.9999,42.75L26.9166,53.8334L22.1666,49.0833L33.25,38L22.1667,26.9167L26.9166,22.1667 Z "}
+            AddHandler DeleteItem.Click, Sub() DeleteCustomCategoryByName(CategoryName)
+            Menu.Items.Add(DeleteItem)
+            Card.ContextMenu = Menu
+        Catch ex As Exception
+            Logger.Warn(ex, "附加自定义分类右键菜单失败")
+        End Try
+    End Sub
+
+#End Region
+
+#Region "自定义分类管理"
+
+    ''' <summary>弹出新建自定义分类的对话框并创建分类。</summary>
+    Public Sub PromptCreateCustomCategory()
+        Try
+            Dim Name As String = MyMsgBoxInput("新建自定义分类", "请输入分类的名称（用于在版本列表中标识该分类）", "",
+                New ObjectModel.Collection(Of Validate) From {
+                    New ValidateNullOrWhiteSpace,
+                    New ValidateLength(1, 20),
+                    New ValidateExcept({">", "|", ":"})
+                })
+            If String.IsNullOrWhiteSpace(Name) Then Return
+            If McCustomCategories.ContainsKey(Name) Then
+                Hint($"已存在同名分类 {Name}！", HintType.Red)
+                Return
+            End If
+            If CreateCustomCategory(McFolderSelected, Name) Then
+                Hint($"已创建自定义分类 {Name}", HintType.Green)
+                RefreshAfterCustomCategoryChange()
+            End If
+        Catch ex As Exception
+            Logger.Error(ex, "新建自定义分类失败")
+        End Try
+    End Sub
+
+    ''' <summary>弹窗确认后重命名一个自定义分类。</summary>
+    Public Sub PromptRenameCustomCategory(OldName As String)
+        Try
+            Dim NewName As String = MyMsgBoxInput("重命名分类", $"将分类 {OldName} 重命名为：", OldName,
+                New ObjectModel.Collection(Of Validate) From {
+                    New ValidateNullOrWhiteSpace,
+                    New ValidateLength(1, 20),
+                    New ValidateExcept({">", "|", ":"})
+                })
+            If String.IsNullOrWhiteSpace(NewName) OrElse NewName = OldName Then Return
+            If McCustomCategories.ContainsKey(NewName) Then
+                Hint($"已存在同名分类 {NewName}！", HintType.Red)
+                Return
+            End If
+            If RenameCustomCategory(McFolderSelected, OldName, NewName) Then
+                Hint($"分类 {OldName} 已重命名为 {NewName}", HintType.Green)
+                RefreshAfterCustomCategoryChange()
+            End If
+        Catch ex As Exception
+            Logger.Error(ex, "重命名自定义分类失败")
+        End Try
+    End Sub
+
+    ''' <summary>删除自定义分类。</summary>
+    Public Sub DeleteCustomCategoryByName(CategoryName As String)
+        Try
+            If MyMsgBox($"确定要删除自定义分类 {CategoryName} 吗？" & vbCrLf & "该分类下的版本关联将被一并清除（不会影响版本本身）。",
+                       "删除自定义分类", "删除", "取消") <> 1 Then Return
+            If DeleteCustomCategory(McFolderSelected, CategoryName) Then
+                Hint($"已删除自定义分类 {CategoryName}", HintType.Green)
+                RefreshAfterCustomCategoryChange()
+            End If
+        Catch ex As Exception
+            Logger.Error(ex, "删除自定义分类失败")
+        End Try
+    End Sub
+
+    ''' <summary>从自定义分类中移除一个版本（带提示与刷新）。</summary>
+    Public Sub PromptRemoveInstanceFromCategory(CategoryName As String, Instance As McInstance)
+        Try
+            If RemoveInstanceFromCategory(McFolderSelected, CategoryName, Instance.Name) Then
+                Hint($"已从 {CategoryName} 中移除 {Instance.Name}", HintType.Green)
+                RefreshAfterCustomCategoryChange()
+            End If
+        Catch ex As Exception
+            Logger.Error(ex, "从自定义分类中移除版本失败")
+        End Try
+    End Sub
+
+    ''' <summary>
+    ''' 在分类卡底部打开一个选择器，把版本加入此分类（先过滤掉已经在该分类中的）。
+    ''' </summary>
+    Private Sub AddInstanceToCategoryPicker(CategoryName As String, AlreadyInCategory As List(Of McInstance), NameToInstance As Dictionary(Of String, McInstance))
+        Try
+            Dim Cat = McCustomCategories(CategoryName)
+            Dim InCat As New HashSet(Of String)(Cat.InstanceNames)
+            Dim Candidates = NameToInstance.Values.
+                Where(Function(i) Not InCat.Contains(i.Name)).
+                OrderBy(Function(i) i.Name).
+                ToList()
+            If Not Candidates.Any Then
+                Hint("已经所有版本都在此分类中了", HintType.Blue)
+                Return
+            End If
+            'MyMsgBoxSelect 要求第一个参数为 IEnumerable(Of IMyRadio)，并以 0-based 索引返回（Nothing = 取消）。
+            Dim Selections As New List(Of IMyRadio)
+            For Each Inst In Candidates
+                Selections.Add(New MyRadioBox With {.Text = Inst.Name})
+            Next
+            Dim SelectedIndex As Integer? = MyMsgBoxSelect(Selections,
+                $"请选择要加入 {CategoryName} 的版本",
+                "加入", "取消")
+            If SelectedIndex Is Nothing Then Return
+            If SelectedIndex < 0 OrElse SelectedIndex >= Candidates.Count Then Return
+            Dim Selected As McInstance = Candidates(SelectedIndex.Value)
+            If AddInstanceToCategory(McFolderSelected, CategoryName, Selected.Name) Then
+                Hint($"已把 {Selected.Name} 加入 {CategoryName}", HintType.Green)
+                RefreshAfterCustomCategoryChange()
+            End If
+        Catch ex As Exception
+            Logger.Error(ex, "把版本加入自定义分类失败")
+        End Try
+    End Sub
+
+    ''' <summary>统一的"自定义分类"变更后的 UI 刷新入口。</summary>
+    Private Sub RefreshAfterCustomCategoryChange()
+        McInstanceListForceRefresh = True
+        LoaderFolderRun(McInstanceListLoader, McFolderSelected, LoaderFolderRunType.ForceRun, MaxDepth:=1, ExtraPath:="versions\")
+    End Sub
+
+#End Region
+
+#Region "拖拽"
+
+    ' 减号图标的 Path Data（MyIconButton.Logo 接受 path data 字符串）
+    Private Const IconDataMinus As String = "M0,9 L24,9 L24,15 L0,15 Z"
+
+    ''' <summary>
+    ''' 在自定义分类卡内拖拽排序时附带的数据。
+    ''' </summary>
+    Public Class CustomCategoryDragData
+        Public CategoryName As String
+        Public InstanceName As String
+    End Class
+
+    ''' <summary>
+    ''' 为单个自定义分类卡内的 <see cref="MyListItem"/> 启用拖拽排序。
+    ''' 仅在同一个分类卡的项之间拖动生效；不允许跨分类卡的拖拽。
+    ''' </summary>
+    Public Sub EnableCustomCategoryItemDrag(Item As MyListItem, CategoryName As String)
+        Try
+            Item.AllowDrop = True
+            Dim StartPoint As Point = New Point(0, 0)
+            Dim DragStarted As Boolean = False
+            Dim SrcCategory As String = CategoryName
+            Dim SrcInstanceName As String = ""
+            AddHandler Item.PreviewMouseLeftButtonDown, Sub(s, e)
+                StartPoint = e.GetPosition(Nothing)
+                Dim SrcInst As McInstance = TryCast(Item.Tag, McInstance)
+                SrcInstanceName = If(SrcInst Is Nothing, "", SrcInst.Name)
+                DragStarted = False
+            End Sub
+            AddHandler Item.PreviewMouseMove, Sub(s, e)
+                Dim SrcItem As MyListItem = CType(s, MyListItem)
+                If DragStarted OrElse e.LeftButton <> MouseButtonState.Pressed Then Return
+                Dim Cur = e.GetPosition(Nothing)
+                If Math.Abs(Cur.X - StartPoint.X) >= SystemParameters.MinimumHorizontalDragDistance OrElse
+                   Math.Abs(Cur.Y - StartPoint.Y) >= SystemParameters.MinimumVerticalDragDistance Then
+                    If String.IsNullOrEmpty(SrcInstanceName) Then Return
+                    DragStarted = True
+                    Try
+                        Dim Payload As New CustomCategoryDragData With {.CategoryName = SrcCategory, .InstanceName = SrcInstanceName}
+                        Dim DataObj As New DataObject(GetType(CustomCategoryDragData), Payload)
+                        DragDrop.DoDragDrop(SrcItem, DataObj, DragDropEffects.Move)
+                    Finally
+                        DragStarted = False
+                    End Try
+                End If
+            End Sub
+            AddHandler Item.PreviewDragOver, Sub(s, e)
+                Dim Data = TryCast(e.Data.GetData(GetType(CustomCategoryDragData)), CustomCategoryDragData)
+                Dim TargetInst As McInstance = TryCast(Item.Tag, McInstance)
+                If Data IsNot Nothing AndAlso TargetInst IsNot Nothing AndAlso
+                   Data.CategoryName = CategoryName AndAlso Data.InstanceName <> TargetInst.Name Then
+                    e.Effects = DragDropEffects.Move
+                Else
+                    e.Effects = DragDropEffects.None
+                End If
+                e.Handled = True
+            End Sub
+            AddHandler Item.PreviewDrop, Sub(s, e)
+                Dim Data = TryCast(e.Data.GetData(GetType(CustomCategoryDragData)), CustomCategoryDragData)
+                If Data Is Nothing OrElse Data.CategoryName <> CategoryName Then Return
+                Dim TargetInst As McInstance = TryCast(Item.Tag, McInstance)
+                If TargetInst Is Nothing Then Return
+                Try
+                    Dim CatList As List(Of String) = McCustomCategories(CategoryName).InstanceNames
+                    Dim SrcIdx As Integer = CatList.IndexOf(Data.InstanceName)
+                    Dim TgtIdx As Integer = CatList.IndexOf(TargetInst.Name)
+                    If SrcIdx < 0 OrElse TgtIdx < 0 OrElse SrcIdx = TgtIdx Then Return
+                    MoveInstanceInCategory(McFolderSelected, CategoryName, SrcIdx, TgtIdx)
+                    Hint($"已在 {CategoryName} 内调整顺序", HintType.Green)
+                    RefreshAfterCustomCategoryChange()
+                Catch ex As Exception
+                    Logger.Error(ex, "拖拽换位失败")
+                End Try
+                e.Handled = True
+            End Sub
+        Catch ex As Exception
+            Logger.Warn(ex, "为自定义分类项启用拖拽失败")
+        End Try
+    End Sub
+
+#End Region
+
+End Class

--- a/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
+++ b/Plain Craft Launcher 2/Plain Craft Launcher 2.vbproj
@@ -352,6 +352,8 @@
     <Compile Include="Pages\PageSelectLeft.xaml.vb">
       <DependentUpon>PageSelectLeft.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\PageSelectRightCategory.vb" />
+    <Compile Include="Pages\PageSelectLeftDrag.vb" />
     <Compile Include="Pages\PageLaunch\PageLaunchLeft.xaml.vb">
       <DependentUpon>PageLaunchLeft.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
数据层（ModMinecraft.vb）：
- 新增 McCustomCategory 实体（分类名 + 顺序的实例名列表）
- 新增 McCustomCategories 全局字典与 8 个 CRUD/持久化入口 （LoadCustomCategories / SaveCustomCategories / CreateCustomCategory / DeleteCustomCategory / RenameCustomCategory / AddInstanceToCategory / RemoveInstanceFromCategory / MoveInstanceInCategory）
- 在 InitMcInstanceList 末尾挂钩 LoadCustomCategories，自动清理失效实例并保存

UI 渲染（PageSelectRightCategory.vb）：
- RenderCustomCategoryCards 在系统分类卡后追加用户分类卡
- 自定义分类下实例同时显示在该分类与原系统分类中
- 分类卡右键菜单支持重命名 / 删除
- 底部 `+ 新建分类` 与 `+ 把版本加入 xxx` 入口
- 所有变更后通过 RefreshAfterCustomCategoryChange 强制刷新版本列表

拖拽（PageSelectRightCategory.vb + PageSelectLeftDrag.vb）：
- 右侧自定义分类卡内：拖动实例卡片调整顺序，松手立即写盘并刷新
- 左侧文件夹列表：拖动文件夹项调整顺序，松手立即写盘并刷新

风格对齐：
- 新增 partial class 文件平铺在 Pages/ 根目录
- 使用 #Region 与现有代码一致
- 函数命名 PromptXxx / XxxYyy 风格
- 错误处理沿用 Try + Logger.Error(ex, 中文描述)