### PR TITLE
fix: 修复自定义主页 MyCard 使用 Inlines 后无法折叠

### DIFF
--- a/Plain Craft Launcher 2/Controls/MyCard.vb
+++ b/Plain Craft Launcher 2/Controls/MyCard.vb
@@ -14,6 +14,13 @@ Public Class MyCard
         End Set
     End Property
     Private _MainTextBlock As TextBlock
+    Private Sub InitMainTextBlock()
+        If _MainTextBlock IsNot Nothing Then Return
+        _MainTextBlock = New TextBlock With {.HorizontalAlignment = HorizontalAlignment.Left, .VerticalAlignment = VerticalAlignment.Top, .Margin = New Thickness(15, 12, 0, 0), .FontWeight = FontWeights.Bold, .FontSize = 13, .IsHitTestVisible = False}
+        _MainTextBlock.SetResourceReference(TextBlock.ForegroundProperty, "ColorBrush1")
+        _MainTextBlock.SetBinding(TextBlock.TextProperty, New Binding("Title") With {.Source = Me, .Mode = BindingMode.OneWay})
+        MainGrid.Children.Add(_MainTextBlock)
+    End Sub
     Public Property MainTextBlock As TextBlock
         Get
             Init() '当父级触发 Loaded 时，本卡片可能尚未触发 Loaded（该事件从父级向子级调用），因此这会是 null。手动触发以确保控件已加载。
@@ -38,7 +45,8 @@ Public Class MyCard
     Public Uuid As Integer = GetUuid()
     Public ReadOnly Property Inlines As InlineCollection
         Get
-            Return MainTextBlock.Inlines
+            InitMainTextBlock()
+            Return _MainTextBlock.Inlines
         End Get
     End Property
     Public Property CornerRadius As CornerRadius
@@ -77,12 +85,7 @@ Public Class MyCard
         If IsLoad Then Return
         IsLoad = True
         '初次加载限定
-        If MainTextBlock Is Nothing Then
-            MainTextBlock = New TextBlock With {.HorizontalAlignment = HorizontalAlignment.Left, .VerticalAlignment = VerticalAlignment.Top, .Margin = New Thickness(15, 12, 0, 0), .FontWeight = FontWeights.Bold, .FontSize = 13, .IsHitTestVisible = False}
-            MainTextBlock.SetResourceReference(TextBlock.ForegroundProperty, "ColorBrush1")
-            MainTextBlock.SetBinding(TextBlock.TextProperty, New Binding("Title") With {.Source = Me, .Mode = BindingMode.OneWay})
-            MainGrid.Children.Add(MainTextBlock)
-        End If
+        InitMainTextBlock()
         If CanSwap OrElse SwapControl IsNot Nothing Then
             If SwapControl Is Nothing AndAlso Children.Count > 3 Then SwapControl = Children(3)
             MainSwap = New Shapes.Path With {.HorizontalAlignment = HorizontalAlignment.Right, .Stretch = Stretch.Uniform, .Height = 6, .Width = 10, .VerticalAlignment = VerticalAlignment.Top, .Margin = New Thickness(0, 17, 16, 0), .Data = New GeometryConverter().ConvertFromString("M2,4 l-2,2 10,10 10,-10 -2,-2 -8,8 -8,-8 z"), .RenderTransform = New RotateTransform(180), .RenderTransformOrigin = New Point(0.5, 0.5)}


### PR DESCRIPTION
## 修改内容

修复自定义主页中的 `MyCard` 在使用 `Inlines` 自定义标题后无法正常折叠的问题。

将 `MainTextBlock` 的创建逻辑提取为 `InitMainTextBlock`：

- `Inlines` 只初始化标题 `TextBlock`，不再提前触发完整的 `MyCard.Init()`；
- `MyCard` 仍在 `Loaded` 阶段执行完整初始化；
- 保留 `MainTextBlock` 属性原有的初始化行为，不影响现有调用。

## 问题原因

`MyCard.Inlines` 原先通过 `MainTextBlock.Inlines` 获取集合，而 `MainTextBlock` 的 Getter 会调用 `Init()`。

自定义主页解析 XAML 时，读取 `MyCard.Inlines` 的阶段正文控件尚未加入 `Children`，导致：

- `Children.Count` 只有 3；
- `SwapControl` 无法保存正文控件；
- `IsLoad` 被提前设置为 `True`；
- 后续 `Loaded` 事件直接返回；
- 卡片最终无法折叠。

本 PR 使 `Inlines` 只初始化标题控件，避免在 XAML 内容完成加载前提前执行完整初始化。

## 验证

- Debug 构建通过
- Release 构建通过
- 普通 `MyCard` 可正常折叠/展开
- 使用 `MyCard.Inlines` 后可正常折叠/展开
- `IsSwapped="True"` 时可正确默认折叠
- `IsSwapped="False"` 时可正确默认展开
- `CanSwap="False"` 时行为不变
- 自定义主页刷新后行为正常
- `git diff --check` 通过

Fixes #9162