### PR TITLE
fix(resource): 修复手动输入版本号时加载器选择被清空

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
@@ -246,14 +246,14 @@ Public Class PageResource
         If Not TextSearchVersion.IsDropDownOpen Then UpdateSearchLoaderVisibility()
     End Sub
     Private Sub UpdateSearchLoaderVisibility() Handles TextSearchVersion.DropDownClosed
-        If PageType = ResourceTypes.Mod AndAlso TextSearchVersion.Text <> "" AndAlso TextSearchVersion.Text <> "全部 (也可自行输入)" Then
+        If PageType = ResourceTypes.Mod AndAlso (TextSearchVersion.Text.Contains(".") OrElse TextSearchVersion.Text.Contains("w")) Then
             ComboSearchLoader.Visibility = Visibility.Visible
             Grid.SetColumnSpan(TextSearchVersion, 1)
         Else
             ComboSearchLoader.Visibility = Visibility.Collapsed
             Grid.SetColumnSpan(TextSearchVersion, 2)
-            '清空输入框是编辑版本号的中间状态，不应清空加载器选择（#9009）
-            If TextSearchVersion.Text <> "" Then ComboSearchLoader.SelectedIndex = 0
+            '空白输入是编辑版本号的中间状态，不应清空加载器选择（#9009）
+            If Not String.IsNullOrWhiteSpace(TextSearchVersion.Text) Then ComboSearchLoader.SelectedIndex = 0
         End If
     End Sub
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
@@ -126,7 +126,7 @@ Public Class PageResource
             .SearchText = TextSearchName.Text
             .GameVersion = GameVersion
             .Tag = ComboSearchTag.SelectedItem.Tag
-            .ModLoaders = If(PageType = ResourceTypes.Mod, Val(ComboSearchLoader.SelectedItem.Tag), ModLoaders.None)
+            .ModLoaders = If(PageType = ResourceTypes.Mod AndAlso GameVersion IsNot Nothing, Val(ComboSearchLoader.SelectedItem.Tag), ModLoaders.None)
             .Sources = CType(Val(ComboSearchSource.SelectedItem.Tag), ResourcePlatforms)
         End With
         Return Request
@@ -252,7 +252,7 @@ Public Class PageResource
         Else
             ComboSearchLoader.Visibility = Visibility.Collapsed
             Grid.SetColumnSpan(TextSearchVersion, 2)
-            ComboSearchLoader.SelectedIndex = 0
+            '输入版本号时可能暂时没有有效版本，保留加载器选择；搜索时忽略隐藏的条件（#9009）
         End If
     End Sub
 

--- a/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageDownload/Resource/PageResource.xaml.vb
@@ -246,13 +246,14 @@ Public Class PageResource
         If Not TextSearchVersion.IsDropDownOpen Then UpdateSearchLoaderVisibility()
     End Sub
     Private Sub UpdateSearchLoaderVisibility() Handles TextSearchVersion.DropDownClosed
-        If PageType = ResourceTypes.Mod AndAlso (TextSearchVersion.Text.Contains(".") OrElse TextSearchVersion.Text.Contains("w")) Then
+        If PageType = ResourceTypes.Mod AndAlso TextSearchVersion.Text <> "" AndAlso TextSearchVersion.Text <> "全部 (也可自行输入)" Then
             ComboSearchLoader.Visibility = Visibility.Visible
             Grid.SetColumnSpan(TextSearchVersion, 1)
         Else
             ComboSearchLoader.Visibility = Visibility.Collapsed
             Grid.SetColumnSpan(TextSearchVersion, 2)
-            '输入版本号时可能暂时没有有效版本，保留加载器选择；搜索时忽略隐藏的条件（#9009）
+            '清空输入框是编辑版本号的中间状态，不应清空加载器选择（#9009）
+            If TextSearchVersion.Text <> "" Then ComboSearchLoader.SelectedIndex = 0
         End If
     End Sub
 


### PR DESCRIPTION
避免版本输入暂为空白时清空已选 Mod 加载器。按 review 恢复原有加载器显示条件，仅在隐藏分支使用 `Not String.IsNullOrWhiteSpace(TextSearchVersion.Text)` 判断是否重置。搜索请求仍仅在有有效 GameVersion 时使用加载器条件。

Refs #9009（尚未完整解决，不自动关闭）

验证与限制：
- 源方法提取的 STA/WPF 隔离夹具中，59 项定向断言通过：Forge/Fabric、空串/空格/Tab、完整版本、快照、全部版本重置、非 Mod 页面及重置条件。
- 保留的逐字输入回归仍失败：已选 Forge → 清空 → 输入 `1`，此时不含点或 w，原有显示条件会进入隐藏分支，非空判断仍重置选择。因此本修订只解决空白中间状态，不能宣称整个 issue 已解决。
- 本地 review、git diff --check 通过；未完成完整构建或真实 PCL UI 验证，本机缺现代 MSBuild/.NET 4.8 targeting pack，CI 待批准。