### PR TITLE
fix(instance): 修复拖入第三方登录地址后版本描述未刷新

### DIFF
--- a/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
+++ b/Plain Craft Launcher 2/Pages/PageInstance/PageInstanceSetup.xaml.vb
@@ -324,12 +324,12 @@ PreFin:
 #Region "服务器"
 
     '当第三方登录更改时，清空版本列表缓存以更新版本分类
-    'TODO: 这会不会导致拖拽改变第三方登录的时候版本列表缓存没有更新？
     Public Shared Sub OnVersionServerLoginChanged(Type As Integer)
-        If FrmInstanceSetup Is Nothing Then Return
         WriteIni(McFolderSelected & "PCL.ini", "InstanceCache", "")
-        If PageInstanceLeft.Instance Is Nothing Then Return
-        PageInstanceLeft.Instance = New McInstance(PageInstanceLeft.Instance.Name).Load()
+        '拖拽设置第三方登录时，版本设置页可能尚未初始化，但仍需刷新版本列表
+        If FrmInstanceSetup IsNot Nothing AndAlso PageInstanceLeft.Instance IsNot Nothing Then
+            PageInstanceLeft.Instance = New McInstance(PageInstanceLeft.Instance.Name).Load()
+        End If
         LoaderFolderRun(McInstanceListLoader, McFolderSelected, LoaderFolderRunType.ForceRun, MaxDepth:=1, ExtraPath:="versions\")
     End Sub
 


### PR DESCRIPTION
拖入 Authlib-Injector 登录地址后，如果版本设置页尚未初始化，版本列表仍显示旧描述。设置变更回调在清空缓存之前提前返回，因此重新打开版本列表也可能继续使用旧结果。

将缓存失效和版本列表重载移到页面存在性判断之外，只对版本设置页实例的更新保留空值检查。LittleSkin 和通用 Authlib 拖拽共用该回调，现有设置页修改登录方式的刷新行为保持不变。

Fixes #9136

验证：
- 从修改后的源文件提取实际 VB 回调，使用系统 VB 编译器编译隔离测试，以替身记录缓存写入、列表重载和实例加载；覆盖设置页存在/不存在、实例存在/不存在，以及登录类型 0、3、4，共 12 个组合，全部通过。相同测试对 origin/main 原始回调失败。
- 本地代码 review、git diff --check 通过。
- 完整构建未通过环境检查：本机仅发现 .NET Framework 自带旧版 MSBuild，缺少 .NET 4.8 targeting pack，且无法加载 SDK 风格的 PCLCS.csproj（MSB4041）。以上隔离测试不代表完整项目构建通过。
- 未进行真实 WPF UI 验证。建议按 issue 步骤，在未打开版本设置页的情况下拖入 LittleSkin/通用 Authlib 地址，确认后检查版本列表；另检查取消操作及自定义版本描述保持原样。
