### PR TITLE
fix(instance): 修复安装 Mod 加载器后愚人节版本显示为快照版

### DIFF
--- a/PCLCS/Constants.cs
+++ b/PCLCS/Constants.cs
@@ -72,7 +72,7 @@ public static class Versions {
     /// <summary>
     /// Minecraft 本地实例信息缓存的版本号。
     /// </summary>
-    public const int McInstanceCacheVersion = 38;
+    public const int McInstanceCacheVersion = 39;
     /// <summary>
     /// Java 相关配置的版本号。
     /// </summary>

--- a/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
+++ b/Plain Craft Launcher 2/Modules/Minecraft/ModMinecraft.vb
@@ -744,11 +744,7 @@ Recheck:
                     Case Else '根据 API 进行筛选
                         Dim RealJson As String = If(JsonObject, JsonText).ToString
                         '愚人节与快照版本
-                        Dim FixedReleaseTime = ReleaseTime.ToUniversalTime().AddHours(2)
-                        Dim JsonType = If(JsonObject("type"), "").ToString
-                        If JsonType = "fool" OrElse
-                           (FixedReleaseTime.Month = 4 AndAlso FixedReleaseTime.Day = 1 AndAlso JsonType = "snapshot") OrElse
-                           GetMcFoolName(Version.VanillaName) <> "" Then
+                        If IsFool() Then
                             State = McInstanceState.Fool
                         ElseIf IsSnapshot() Then
                             State = McInstanceState.Snapshot
@@ -850,6 +846,14 @@ ExitDataLoad:
             End Try
             Return Me
         End Function
+        Private Function IsFool() As Boolean
+            Dim FixedReleaseTime = ReleaseTime.ToUniversalTime().AddHours(2)
+            Dim JsonType = If(JsonObject("type"), "").ToString
+            Return JsonType = "fool" OrElse
+                   (FixedReleaseTime.Month = 4 AndAlso FixedReleaseTime.Day = 1 AndAlso JsonType = "snapshot") OrElse
+                   GetMcFoolName(Version.VanillaName) <> ""
+        End Function
+
         Private Function IsSnapshot() As Boolean
             Dim jsonType As String = If(JsonObject("type"), "").ToString
             Return {"w", "snapshot", "rc", "pre", "experimental", "-"}.Any(Function(s) Version.VanillaName.ContainsIgnoreCase(s)) OrElse
@@ -874,7 +878,9 @@ ExitDataLoad:
             Dim Info As String
             Select Case State
                 Case McInstanceState.Snapshot, McInstanceState.Original, McInstanceState.Forge, McInstanceState.NeoForge, McInstanceState.Fabric, McInstanceState.OptiFine, McInstanceState.LiteLoader
-                    If Version.VanillaName.ContainsIgnoreCase("pre") Then
+                    If IsFool() Then
+                        Info = "愚人节版本 " & Version.VanillaName
+                    ElseIf Version.VanillaName.ContainsIgnoreCase("pre") Then
                         Info = "预发布版 " & Version.VanillaName
                     ElseIf Version.VanillaName.ContainsIgnoreCase("rc") Then
                         Info = "发布候选 " & Version.VanillaName


### PR DESCRIPTION
安装 Fabric 等加载器后，实例状态会变为加载器类型，版本描述因此绕过原有的愚人节分类，显示成“快照版”。本修改复用实例加载时的愚人节判断，使 `26w14a + Fabric 0.19.3` 显示为“愚人节版本 26w14a, Fabric 0.19.3”。加载器状态、Mod 管理能力和加载器后缀保持原样。

将实例缓存版本从 38 提升为 39，让已有安装重新生成描述。没有修改愚人节识别规则：仍使用 JSON 类型、UTC+2 的 4 月 1 日快照日期和现有版本名表。

验证：
- 将实际 `IsFool`、`IsSnapshot`、`VersionDisplayName` 和 `GetMcFoolName` 方法提取到隔离 VB 程序，以 .NET Framework 自带 vbc 编译执行；版本/JSON 数据容器与字符串扩展使用测试替身。旧代码在 `26w14a + Fabric 0.19.3` 用例失败，修改后 28 个用例通过，覆盖已知愚人节版本、日期边界、不同加载器、正式版/快照/预发布/候选版和错误状态。
- 本地 diff review 和 `git diff --check` 通过；检查了缓存读取及刷新路径。
- 完整构建未通过环境检查：系统只有旧 MSBuild 4.0，缺少 .NET Framework 4.8 引用程序集，构建在 SDK 格式的 PCLCS 项目报 MSB4041；未完成完整项目编译。
- 未进行真实 PCL UI 验证。

Fixes #9259
